### PR TITLE
feat(sdk): implement multicall batching for read-only queries

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -126,6 +126,36 @@ export class bcForgeClient {
     return scValToNative(result) as string;
   }
 
+  // ─── Batch Queries ───────────────────────────────────────────────────────
+
+  /**
+   * Get token balances for multiple addresses in batches.
+   *
+   * @param addresses - Array of Stellar public keys
+   * @param batchSize - Maximum number of concurrent queries (default: 10)
+   * @returns Array of balances as bigints
+   */
+  async getBalances(addresses: string[], batchSize: number = 10): Promise<bigint[]> {
+    return this.executeBatch(addresses, (addr) => this.getBalance(addr), batchSize);
+  }
+
+  /**
+   * Internal helper to execute a list of async tasks in chunks using Promise.all.
+   */
+  private async executeBatch<T, R>(
+    items: T[],
+    task: (item: T) => Promise<R>,
+    batchSize: number
+  ): Promise<R[]> {
+    const results: R[] = [];
+    for (let i = 0; i < items.length; i += batchSize) {
+      const chunk = items.slice(i, i + batchSize);
+      const batchResults = await Promise.all(chunk.map((item) => task(item)));
+      results.push(...batchResults);
+    }
+    return results;
+  }
+
   // ─── Write Transactions ──────────────────────────────────────────────────
 
   /**


### PR DESCRIPTION
## Description
This PR augments the `@bc-forge/sdk` with batching capabilities for read-only contract queries. It addresses the overhead of sequential RPC calls when querying multiple data points (e.g., balances for a list of holders) by consolidating requests into asynchronous groupings.

## Key Changes
- **Batch Execution Engine**: Added an internal `executeBatch` helper to [bcForgeClient](cci:2://file:///home/edohwares/Desktop/Room/drips/bc-forge/sdk/src/client.ts:47:0-319:1) that processes arrays in configurable chunks using `Promise.all`.
- **Native Balance Batching**: Implemented `getBalances(addresses[], batchSize)` for efficient multi-address lookups.
- **RPC Protection**: Integrated batch limits (default: 10) to prevent aggressive rate-limiting from Soroban RPC endpoints.

## Acceptance Criteria
- [x] Map arrays iterating explicitly requesting Promise.all logic.
- [x] Consolidate query limits protecting RPC configurations.
- [x] Ensure SDK output variants format object results relative to requests.

Closes #28 