### PR TITLE
[SDK]: Add error handling, retries, and typed SDK errors

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -23,6 +23,8 @@ import {
   scValToNative,
 } from './utils';
 
+import { SimulationError, RPCError } from './errors';
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface bcForgeClientConfig {
@@ -286,33 +288,60 @@ export class bcForgeClient {
   // ─── Internal Helpers ────────────────────────────────────────────────────
 
   /**
+   * Internal helper to execute a task with retries.
+   */
+  private async withRetry<T>(fn: () => Promise<T>, retries: number = 3): Promise<T> {
+    let lastError: any;
+    for (let i = 0; i < retries; i++) {
+      try {
+        return await fn();
+      } catch (error) {
+        lastError = error;
+        // Only retry on certain errors (e.g., network/RPC errors)
+        // For now, we retry on any error that isn't a known terminal error
+        if (i < retries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000 * (i + 1)));
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  /**
    * Simulates a read-only contract call (no transaction submission).
    */
   private async queryContract(method: string, args: xdr.ScVal[]): Promise<xdr.ScVal> {
-    const account = new (await import('@stellar/stellar-sdk')).Account(
-      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-      '0'
-    );
+    return this.withRetry(async () => {
+      try {
+        const account = new (await import('@stellar/stellar-sdk')).Account(
+          'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+          '0'
+        );
 
-    const tx = new TransactionBuilder(account, {
-      fee: '100',
-      networkPassphrase: this.networkPassphrase,
-    })
-      .addOperation(this.contract.call(method, ...args))
-      .setTimeout(30)
-      .build();
+        const tx = new TransactionBuilder(account, {
+          fee: '100',
+          networkPassphrase: this.networkPassphrase,
+        })
+          .addOperation(this.contract.call(method, ...args))
+          .setTimeout(30)
+          .build();
 
-    const simulated = await this.server.simulateTransaction(tx);
+        const simulated = await this.server.simulateTransaction(tx);
 
-    if (SorobanRpc.Api.isSimulationError(simulated)) {
-      throw new Error(`Query failed: ${simulated.error}`);
-    }
+        if (SorobanRpc.Api.isSimulationError(simulated)) {
+          throw new SimulationError(`Query failed: ${simulated.error}`, simulated.error);
+        }
 
-    if (!SorobanRpc.Api.isSimulationSuccess(simulated) || !simulated.result) {
-      throw new Error('Query returned no result');
-    }
+        if (!SorobanRpc.Api.isSimulationSuccess(simulated) || !simulated.result) {
+          throw new SimulationError('Query returned no result');
+        }
 
-    return simulated.result.retval;
+        return simulated.result.retval;
+      } catch (error: any) {
+        if (error instanceof SimulationError) throw error;
+        throw new RPCError('RPC call failed', error);
+      }
+    });
   }
 
   /**
@@ -323,28 +352,36 @@ export class bcForgeClient {
     args: xdr.ScVal[],
     source: Keypair
   ): Promise<TransactionResult> {
-    const txXdr = await buildInvokeTransaction(
-      this.rpcUrl,
-      this.networkPassphrase,
-      this.contractId,
-      method,
-      args,
-      source
-    );
+    return this.withRetry(async () => {
+      try {
+        const txXdr = await buildInvokeTransaction(
+          this.rpcUrl,
+          this.networkPassphrase,
+          this.contractId,
+          method,
+          args,
+          source
+        );
 
-    const response = await submitTransaction(this.rpcUrl, txXdr);
+        const response = await submitTransaction(this.rpcUrl, txXdr);
 
-    if (response.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
-      return {
-        success: true,
-        hash: (response as any).hash,
-        returnValue: response.returnValue ? scValToNative(response.returnValue) : undefined,
-      };
-    }
+        if (response.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+          return {
+            success: true,
+            hash: (response as any).hash,
+            returnValue: response.returnValue ? scValToNative(response.returnValue) : undefined,
+          };
+        }
 
-    return {
-      success: false,
-      hash: (response as any).hash,
-    };
+        return {
+          success: false,
+          hash: (response as any).hash,
+        };
+      } catch (error: any) {
+        // Don't retry on simulation errors (usually logic errors)
+        if (error instanceof SimulationError) throw error;
+        throw error;
+      }
+    });
   }
 }

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1,0 +1,53 @@
+/**
+ * @bc-forge/sdk — Custom Error Classes
+ */
+
+/**
+ * Base class for all SDK errors.
+ */
+export class bcForgeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'bcForgeError';
+  }
+}
+
+/**
+ * Thrown when a contract simulation fails.
+ */
+export class SimulationError extends bcForgeError {
+  constructor(message: string, public readonly errorDetails?: string) {
+    super(message);
+    this.name = 'SimulationError';
+  }
+}
+
+/**
+ * Thrown when a transaction submission fails at the RPC level.
+ */
+export class TransactionSubmissionError extends bcForgeError {
+  constructor(message: string, public readonly hash?: string) {
+    super(message);
+    this.name = 'TransactionSubmissionError';
+  }
+}
+
+/**
+ * Thrown when a transaction is not found after polling.
+ */
+export class TransactionTimeoutError extends bcForgeError {
+  constructor(message: string, public readonly hash: string) {
+    super(message);
+    this.name = 'TransactionTimeoutError';
+  }
+}
+
+/**
+ * Thrown when an RPC call fails due to transient network issues.
+ */
+export class RPCError extends bcForgeError {
+  constructor(message: string, public readonly originalError?: any) {
+    super(message);
+    this.name = 'RPCError';
+  }
+}

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -6,15 +6,15 @@ import {
   SorobanRpc,
   TransactionBuilder,
   Networks,
-  Operation,
   xdr,
   Address,
   nativeToScVal,
   scValToNative as sdkScValToNative,
   Contract,
   Keypair,
-  Account,
 } from '@stellar/stellar-sdk';
+
+import { SimulationError, TransactionSubmissionError, TransactionTimeoutError } from './errors';
 
 /**
  * Builds an `invokeHostFunction` transaction for a Soroban contract call.
@@ -52,7 +52,7 @@ export async function buildInvokeTransaction(
   const simulated = await server.simulateTransaction(tx);
 
   if (SorobanRpc.Api.isSimulationError(simulated)) {
-    throw new Error(`Simulation failed: ${simulated.error}`);
+    throw new SimulationError('Contract simulation failed', simulated.error);
   }
 
   const assembled = SorobanRpc.assembleTransaction(tx, simulated).build();
@@ -78,7 +78,9 @@ export async function submitTransaction(
   const sendResponse = await server.sendTransaction(tx);
 
   if (sendResponse.status === 'ERROR') {
-    throw new Error(`Transaction submission failed: ${sendResponse.errorResult}`);
+    throw new TransactionSubmissionError(
+      `Transaction submission failed: ${sendResponse.errorResult}`,
+    );
   }
 
   // Poll for completion
@@ -93,7 +95,10 @@ export async function submitTransaction(
   } while (getResponse.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND && attempts < maxAttempts);
 
   if (getResponse.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
-    throw new Error('Transaction not found after maximum polling attempts');
+    throw new TransactionTimeoutError(
+      'Transaction not found after maximum polling attempts',
+      sendResponse.hash,
+    );
   }
 
   return getResponse;


### PR DESCRIPTION
Closes #13. This PR improves error handling in the SDK by introducing typed error classes, adding retry logic for transient RPC failures in both  and  methods, and ensuring simulation errors are properly surfaced.