### PR TITLE
fix: track Cargo.lock for reproducible WASM builds (#58)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Rust
 /target/
 **/*.rs.bk
-Cargo.lock
+# Cargo.lock is tracked for reproducible WASM builds (Soroban/Stellar requirement)
 
 # Soroban compiled output
 *.wasm


### PR DESCRIPTION
## Summary
Remove `Cargo.lock` from `.gitignore` and add a comment explaining it is required for reproducible Soroban/Stellar WASM contract builds.

## Test Plan
- Verified `.gitignore` no longer contains `Cargo.lock` as an ignored pattern
- The comment clearly documents why `Cargo.lock` should be tracked
- No other files modified

## Related Issue
Closes #58

## Bounty Note
Stellar Wave 5 — 200 Points