### PR TITLE
feat(sdk): add batchTransfer, grantMinter, revokeMinter wrappers and export Role enum

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -57,6 +57,12 @@ export interface BatchMintRecipient {
   amount: bigint;
 }
 
+/** Role for role-based access control */
+export enum Role {
+  Admin = 'Admin',
+  Minter = 'Minter',
+}
+
 // ─── Client ──────────────────────────────────────────────────────────────────
 
 export class bcForgeClient {
@@ -227,6 +233,26 @@ export class bcForgeClient {
     );
     const recipientsVec = xdr.ScVal.scvVec(recipientScVals);
     return this.invokeContract('batch_mint', [recipientsVec], source);
+  }
+
+  /**
+   * Batch transfer tokens to multiple recipients. Sender's keypair must authorize the transaction.
+   *
+   * @param from     - Sender address
+   * @param recipients - Array of recipient objects with address and amount
+   * @param source   - Sender's keypair
+   */
+  async batchTransfer(
+    from: string,
+    recipients: BatchMintRecipient[],
+    source: Keypair,
+  ): Promise<TransactionResult> {
+    const recipientsVec = xdr.ScVal.scvVec(
+      recipients.map(({ to, amount }) =>
+        xdr.ScVal.scvVec([addressToScVal(to), i128ToScVal(amount)]),
+      ),
+    );
+    return this.invokeContract('batch_transfer', [addressToScVal(from), recipientsVec], source);
   }
 
   /**
@@ -558,6 +584,36 @@ export class bcForgeClient {
     return this.invokeContract(
       'execute_proposal',
       [nativeToScVal(proposalId, { type: 'u64' })],
+      source,
+    );
+  }
+
+  // ─── RBAC / Role Management ────────────────────────────────────────────────
+
+  /**
+   * Grant the Minter role to an address. Admin-only.
+   *
+   * @param address - Address to grant the Minter role to
+   * @param source  - Admin keypair
+   */
+  async grantMinter(address: string, source: Keypair): Promise<TransactionResult> {
+    return this.invokeContract(
+      'grant_role',
+      [nativeToScVal(Role.Minter), addressToScVal(address)],
+      source,
+    );
+  }
+
+  /**
+   * Revoke the Minter role from an address. Admin-only.
+   *
+   * @param address - Address to revoke the Minter role from
+   * @param source  - Admin keypair
+   */
+  async revokeMinter(address: string, source: Keypair): Promise<TransactionResult> {
+    return this.invokeContract(
+      'revoke_role',
+      [nativeToScVal(Role.Minter), addressToScVal(address)],
       source,
     );
   }

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -16,7 +16,10 @@ export class bcForgeError extends Error {
  * Thrown when a contract simulation fails.
  */
 export class SimulationError extends bcForgeError {
-  constructor(message: string, public readonly errorDetails?: string) {
+  constructor(
+    message: string,
+    public readonly errorDetails?: string,
+  ) {
     super(message);
     this.name = 'SimulationError';
   }
@@ -26,7 +29,10 @@ export class SimulationError extends bcForgeError {
  * Thrown when a transaction submission fails at the RPC level.
  */
 export class TransactionSubmissionError extends bcForgeError {
-  constructor(message: string, public readonly hash?: string) {
+  constructor(
+    message: string,
+    public readonly hash?: string,
+  ) {
     super(message);
     this.name = 'TransactionSubmissionError';
   }
@@ -36,7 +42,10 @@ export class TransactionSubmissionError extends bcForgeError {
  * Thrown when a transaction is not found after polling.
  */
 export class TransactionTimeoutError extends bcForgeError {
-  constructor(message: string, public readonly hash: string) {
+  constructor(
+    message: string,
+    public readonly hash: string,
+  ) {
     super(message);
     this.name = 'TransactionTimeoutError';
   }
@@ -46,7 +55,10 @@ export class TransactionTimeoutError extends bcForgeError {
  * Thrown when an RPC call fails due to transient network issues.
  */
 export class RPCError extends bcForgeError {
-  constructor(message: string, public readonly originalError?: any) {
+  constructor(
+    message: string,
+    public readonly originalError?: any,
+  ) {
     super(message);
     this.name = 'RPCError';
   }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -18,7 +18,7 @@
  * ```
  */
 
-export { bcForgeClient } from './client';
+export { bcForgeClient, Role } from './client';
 export type { BatchMintRecipient, bcForgeClientConfig, TransactionResult } from './client';
 export { buildInvokeTransaction, submitTransaction, scValToNative } from './utils';
 export { bcForgeEventType, decodeEvent, decodeDiagnosticEvent, subscribeEvents } from './events';

--- a/sdk/src/mockClient.ts
+++ b/sdk/src/mockClient.ts
@@ -82,6 +82,36 @@ export class MockBcForgeClient {
     return { success: true, hash: 'mock-hash', returnValue: null };
   }
 
+  async batchTransfer(from: string, recipients: BatchMintRecipient[]): Promise<TransactionResult> {
+    if ((this.accounts[from]?.balance ?? 0n) < recipients.reduce((sum, r) => sum + r.amount, 0n)) {
+      return { success: false, hash: 'mock-hash', returnValue: 'Insufficient balance' };
+    }
+    for (const { to, amount } of recipients) {
+      if (!this.accounts[to]) this.accounts[to] = { balance: 0n, allowances: {} };
+      this.accounts[from].balance -= amount;
+      this.accounts[to].balance += amount;
+    }
+    return { success: true, hash: 'mock-hash', returnValue: null };
+  }
+
+  async updateName(newName: string): Promise<TransactionResult> {
+    this.name = newName;
+    return { success: true, hash: 'mock-hash', returnValue: null };
+  }
+
+  async updateSymbol(newSymbol: string): Promise<TransactionResult> {
+    this.symbol = newSymbol;
+    return { success: true, hash: 'mock-hash', returnValue: null };
+  }
+
+  async grantMinter(_address: string): Promise<TransactionResult> {
+    return { success: true, hash: 'mock-hash', returnValue: null };
+  }
+
+  async revokeMinter(_address: string): Promise<TransactionResult> {
+    return { success: true, hash: 'mock-hash', returnValue: null };
+  }
+
   async transferFrom(
     owner: string,
     spender: string,


### PR DESCRIPTION
## Summary

Adds SDK wrappers for batch transfers, RBAC minter role management, and exports the Role enum for typed usage.

## Changes

### SDK Client (`sdk/src/client.ts`)
- **`batchTransfer(from, recipients, source)`** - Batch transfer tokens to multiple recipients in one transaction
- **`grantMinter(address, source)`** - Grant the Minter role to an address (closes #76)
- **`revokeMinter(address, source)`** - Revoke the Minter role from an address (closes #76)
- **`Role` enum** - Typed enum (`Admin`, `Minter`) for role-based access control

### Package Exports (`sdk/src/index.ts`)
- Exported `Role` enum for consumer use

### Mock Client (`sdk/src/mockClient.ts`)
- Added `batchTransfer()`, `updateName()`, `updateSymbol()`, `grantMinter()`, `revokeMinter()` mock implementations

### Bug Fix
- Fixed `batchTransfer` XDR construction (`scvTuple` → `scvVec`) for Stellar SDK compatibility

Closes #75 
Closes #76 