### PR TITLE
Transaction simulation

### DIFF
--- a/sdk/src/client.test.ts
+++ b/sdk/src/client.test.ts
@@ -97,6 +97,20 @@ describe('bcForgeClient Offline Transaction Builders', () => {
     });
   });
 
+  describe('buildTransferFromTx', () => {
+    it('should build an unsigned transferFrom transaction XDR', async () => {
+      expect(typeof client.buildTransferFromTx).toBe('function');
+      expect(client.buildTransferFromTx.length).toBe(5); // 5 parameters
+    });
+  });
+
+  describe('buildBurnFromTx', () => {
+    it('should build an unsigned burnFrom transaction XDR', async () => {
+      expect(typeof client.buildBurnFromTx).toBe('function');
+      expect(client.buildBurnFromTx.length).toBe(4); // 4 parameters
+    });
+  });
+
   describe('signTx', () => {
     it('should sign a transaction XDR', () => {
       // Create a mock unsigned transaction XDR (simplified for testing)
@@ -121,6 +135,21 @@ describe('bcForgeClient Offline Transaction Builders', () => {
     it('should have simulateTransfer method', () => {
       expect(typeof client.simulateTransfer).toBe('function');
       expect(client.simulateTransfer.length).toBe(4); // 4 parameters
+    });
+
+    it('should have simulateBurn method', () => {
+      expect(typeof client.simulateBurn).toBe('function');
+      expect(client.simulateBurn.length).toBe(3); // 3 parameters
+    });
+
+    it('should have simulateTransferFrom method', () => {
+      expect(typeof client.simulateTransferFrom).toBe('function');
+      expect(client.simulateTransferFrom.length).toBe(5); // 5 parameters
+    });
+
+    it('should have simulateBurnFrom method', () => {
+      expect(typeof client.simulateBurnFrom).toBe('function');
+      expect(client.simulateBurnFrom.length).toBe(4); // 4 parameters
     });
   });
 });

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -251,6 +251,34 @@ export class bcForgeClient {
   }
 
   /**
+   * Transfer tokens from one address to another using an approved allowance.
+   *
+   * @param spender - Address authorized to spend tokens
+   * @param from    - Token owner address
+   * @param to      - Recipient address
+   * @param amount  - Number of tokens to transfer
+   * @param source  - Spender's keypair
+   */
+  async transferFrom(
+    spender: string,
+    from: string,
+    to: string,
+    amount: bigint,
+    source: Keypair,
+  ): Promise<TransactionResult> {
+    return this.invokeContract(
+      'transfer_from',
+      [
+        addressToScVal(spender),
+        addressToScVal(from),
+        addressToScVal(to),
+        i128ToScVal(amount),
+      ],
+      source,
+    );
+  }
+
+  /**
    * Approve a spender to use tokens on your behalf.
    *
    * @param from    - Token owner
@@ -285,6 +313,31 @@ export class bcForgeClient {
    */
   async burn(from: string, amount: bigint, source: Keypair): Promise<TransactionResult> {
     return this.invokeContract('burn', [addressToScVal(from), i128ToScVal(amount)], source);
+  }
+
+  /**
+   * Burn tokens from an address using an approved allowance.
+   *
+   * @param spender - Address authorized to burn tokens
+   * @param from    - Token owner address
+   * @param amount  - Number of tokens to burn
+   * @param source  - Spender's keypair
+   */
+  async burnFrom(
+    spender: string,
+    from: string,
+    amount: bigint,
+    source: Keypair,
+  ): Promise<TransactionResult> {
+    return this.invokeContract(
+      'burn_from',
+      [
+        addressToScVal(spender),
+        addressToScVal(from),
+        i128ToScVal(amount),
+      ],
+      source,
+    );
   }
 
   /**
@@ -362,6 +415,38 @@ export class bcForgeClient {
   }
 
   /**
+   * Build an unsigned transferFrom transaction for offline signing.
+   *
+   * @param spender           - Address authorized to spend tokens
+   * @param from              - Token owner address
+   * @param to                - Recipient address
+   * @param amount            - Number of tokens to transfer
+   * @param sourcePublicKey   - Spender's public key
+   * @returns Unsigned transaction XDR string
+   */
+  async buildTransferFromTx(
+    spender: string,
+    from: string,
+    to: string,
+    amount: bigint,
+    sourcePublicKey: string,
+  ): Promise<string> {
+    return buildUnsignedTransaction(
+      this.rpcUrl,
+      this.networkPassphrase,
+      this.contractId,
+      'transfer_from',
+      [
+        addressToScVal(spender),
+        addressToScVal(from),
+        addressToScVal(to),
+        i128ToScVal(amount),
+      ],
+      sourcePublicKey,
+    );
+  }
+
+  /**
    * Build an unsigned approve transaction for offline signing.
    *
    * @param from            - Token owner
@@ -403,6 +488,35 @@ export class bcForgeClient {
       this.contractId,
       'burn',
       [addressToScVal(from), i128ToScVal(amount)],
+      sourcePublicKey,
+    );
+  }
+
+  /**
+   * Build an unsigned burnFrom transaction for offline signing.
+   *
+   * @param spender           - Address authorized to burn tokens
+   * @param from              - Token owner address
+   * @param amount            - Number of tokens to burn
+   * @param sourcePublicKey   - Spender's public key
+   * @returns Unsigned transaction XDR string
+   */
+  async buildBurnFromTx(
+    spender: string,
+    from: string,
+    amount: bigint,
+    sourcePublicKey: string,
+  ): Promise<string> {
+    return buildUnsignedTransaction(
+      this.rpcUrl,
+      this.networkPassphrase,
+      this.contractId,
+      'burn_from',
+      [
+        addressToScVal(spender),
+        addressToScVal(from),
+        i128ToScVal(amount),
+      ],
       sourcePublicKey,
     );
   }
@@ -467,6 +581,81 @@ export class bcForgeClient {
     return this.simulate(
       'transfer',
       [addressToScVal(from), addressToScVal(to), i128ToScVal(amount)],
+      sourcePublicKey,
+    );
+  }
+
+  /**
+   * Simulate a transferFrom operation.
+   *
+   * @param spender           - Address authorized to spend tokens
+   * @param from              - Token owner address
+   * @param to                - Recipient address
+   * @param amount            - Number of tokens to transfer
+   * @param sourcePublicKey   - Spender's public key
+   * @returns Simulation result
+   */
+  async simulateTransferFrom(
+    spender: string,
+    from: string,
+    to: string,
+    amount: bigint,
+    sourcePublicKey: string,
+  ): Promise<any> {
+    return this.simulate(
+      'transfer_from',
+      [
+        addressToScVal(spender),
+        addressToScVal(from),
+        addressToScVal(to),
+        i128ToScVal(amount),
+      ],
+      sourcePublicKey,
+    );
+  }
+
+  /**
+   * Simulate a burn operation.
+   *
+   * @param from              - Address whose tokens to burn
+   * @param amount            - Number of tokens to burn
+   * @param sourcePublicKey   - Burner's public key
+   * @returns Simulation result
+   */
+  async simulateBurn(
+    from: string,
+    amount: bigint,
+    sourcePublicKey: string,
+  ): Promise<any> {
+    return this.simulate(
+      'burn',
+      [addressToScVal(from), i128ToScVal(amount)],
+      sourcePublicKey,
+    );
+  }
+
+  /**
+   * Simulate a burnFrom operation.
+   *
+   * @param spender           - Address authorized to burn tokens
+   * @param from              - Token owner address
+   * @param amount            - Number of tokens to burn
+   * @param sourcePublicKey   - Spender's public key
+   * @returns Simulation result
+   */
+  async simulateBurnFrom(
+    spender: string,
+    from: string,
+    amount: bigint,
+    sourcePublicKey: string,
+  ): Promise<any> {
+    return this.simulate(
+      'burn_from',
+      [
+        addressToScVal(spender),
+        addressToScVal(from),
+        i128ToScVal(amount),
+      ],
       sourcePublicKey,
     );
   }

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -660,6 +660,30 @@ export class bcForgeClient {
     );
   }
 
+  /**
+   * Dry-run a transaction to estimate fees and resources without submitting.
+   *
+   * @param txXdr - Transaction XDR string to simulate
+   * @returns Simulation result with estimated resources, fees, and potential return value
+   */
+  async simulateTx(txXdr: string): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    return this.withRetry(async () => {
+      try {
+        const tx = TransactionBuilder.fromXDR(txXdr, this.networkPassphrase);
+        const simulated = await this.server.simulateTransaction(tx);
+
+        if (SorobanRpc.Api.isSimulationError(simulated)) {
+          throw new SimulationError(`Simulation failed: ${simulated.error}`, simulated.error);
+        }
+
+        return simulated;
+      } catch (error: any) {
+        if (error instanceof SimulationError) throw error;
+        throw new RPCError('RPC simulation failed', error);
+      }
+    });
+  }
+
   // ─── Multi-Sig / Admin Pool ──────────────────────────────────────────────
 
   /**

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -825,6 +825,23 @@ export class bcForgeClient {
   }
 
   /**
+   * Poll for recent contract events using cursor-based pagination.
+   *
+   * @param cursor - Optional cursor for pagination (from previous response)
+   * @returns Events response containing events and next cursor
+   */
+  async pollEvents(cursor?: string): Promise<{ events: any[]; cursor: string }> {
+    const response = await this.server.getEvents({
+      cursor,
+      filters: [{ contractIds: [this.contractId], type: 'contract' }],
+    });
+    return {
+      events: response.events,
+      cursor: response.cursor,
+    };
+  }
+
+  /**
    * Update the token symbol. Admin-only.
    *
    * @param newSymbol - The new token symbol


### PR DESCRIPTION
closes #81 


The `simulateTx` method provides a native way to dry-run any Soroban transaction XDR string to estimate computational resources, network fees, and potential return values without submitting the transaction to the blockchain; it accepts a base64-encoded transaction XDR string as input and returns the full `SorobanRpc.Api.SimulateTransactionResponse` object containing detailed simulation results including resource estimates (instructions, memory, read/write operations), fee recommendations, and contract return values when applicable, making it ideal for fee optimization, gas estimation, and transaction validation before submission.
