### PR TITLE
feat(sdk): expose isPaused() method

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -476,6 +476,10 @@ impl BcForgeToken {
         Self::read_pending_admin(&env)
     }
 
+    pub fn is_paused(env: Env) -> bool {
+        bc_forge_lifecycle::is_paused(&env)
+    }
+
     pub fn pause(env: Env) -> Result<(), TokenError> {
         let current_admin = Self::read_admin(&env)?;
         bc_forge_lifecycle::pause(env.clone(), current_admin.clone());

--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -130,3 +130,18 @@ fn test_batch_transfer_while_paused_returns_error() {
         )))
     );
 }
+
+#[test]
+fn test_is_paused_query() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+
+    assert!(!client.is_paused());
+
+    client.pause();
+    assert!(client.is_paused());
+
+    client.unpause();
+    assert!(!client.is_paused());
+}

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -122,6 +122,14 @@ export class bcForgeClient {
   }
 
   /**
+   * Check whether the contract is currently paused.
+   */
+  async isPaused(): Promise<boolean> {
+    const result = await this.queryContract('is_paused', []);
+    return scValToNative(result) as boolean;
+  }
+
+  /**
    * Get the spending allowance from `owner` to `spender`.
    */
   async getAllowance(owner: string, spender: string): Promise<bigint> {


### PR DESCRIPTION
### Summary

Adds a new contract query endpoint for pause state and exposes it in the TypeScript SDK.

### What changed

- Added `is_paused()` query method to `contracts/token/src/lib.rs`
- Added `isPaused()` method to `sdk/src/client.ts`
- Added a token contract test for pause/unpause state query behavior
- Confirmed SDK build compiles after the change

### Fixes

Closes #73