### PR TITLE
chore(ci): optimize CI pipeline with Swatinem rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,10 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
-      - name: Cache Cargo dependencies
-        uses: actions/cache@v4
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-deps-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-deps-
-
-      - name: Cache Cargo target
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.lock') }}-stable
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-
+          shared-key: bc-forge-contracts
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -65,6 +52,8 @@ jobs:
           path: ./tarpaulin-report.html
 
       - name: Build WASM
+        env:
+          CARGO_INCREMENTAL: 0
         run: cargo build --target wasm32-unknown-unknown --release
 
   # ─── TypeScript SDK CI ──────────────────────────────────────────────────


### PR DESCRIPTION
## Description
Optimized the `bc-forge` CI pipeline by implementing `Swatinem/rust-cache@v2`. This replaces manual, brittle cache key management with an automated, intelligent caching strategy for Rust dependencies and incremental build targets.

Closes #89 

## Results
- **Performance Gain**: Reduced Smart Contract CI execution time from ~6m 27s to ~3m 33s (~45% reduction).
- **Reliability**: Eliminated manual `restore-keys` maintenance; the action now automatically handles cache invalidation based on `Cargo.lock` and toolchain changes.
- **Optimization**: Disabled `CARGO_INCREMENTAL` during WASM release builds to streamline the final linking phase.

## Testing
- Validated performance improvements via secondary CI run (cached execution).
- Verified cache hit rates in GitHub Actions logs.

## Performance Comparison
Before (Manual Caching)
<img width="1115" height="455" alt="image" src="https://github.com/user-attachments/assets/eec0cde0-f471-4c67-83cd-cfa81394b2d2" />

After (Swatinem/rust-cache)

<img width="1186" height="451" alt="image" src="https://github.com/user-attachments/assets/4e7d9128-d19f-4dd9-804f-a5b3cc507b0a" />
