### PR TITLE
feat: implement Add token locking/vesting and re-implement admin metadata updates (#63, #55)

### DIFF
--- a/.kiro/specs/metadata-update-functions/.config.kiro
+++ b/.kiro/specs/metadata-update-functions/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d094a61f-2bda-41c1-8a9f-bdc338b59832", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/metadata-update-functions/design.md
+++ b/.kiro/specs/metadata-update-functions/design.md
@@ -1,0 +1,155 @@
+# Design Document: Metadata Update Functions
+
+## Overview
+
+The metadata update functions feature adds administrative capabilities to modify token name and symbol after contract initialization. This design enables token rebranding without contract redeployment while maintaining security through admin-only authorization and providing comprehensive audit trails via event emission.
+
+The feature implements two new contract functions:
+- `update_name(env: Env, new_name: String) -> Result<(), TokenError>` - Updates the token name
+- `update_symbol(env: Env, new_symbol: String) -> Result<(), TokenError>` - Updates the token symbol
+
+Both functions follow the existing token contract patterns for authorization, storage, and event emission.
+
+## Architecture
+
+### High-Level Design
+
+The metadata update system operates within the existing bc-forge Token Contract architecture with three layers:
+
+1. **Admin Authorization Layer** - Verifies caller is admin via `require_auth()`
+2. **Metadata Update Functions** - Core logic for update_name and update_symbol
+3. **Storage & Event Layer** - Persists updates and emits events for audit trail
+
+### Function Signatures
+
+#### update_name
+```rust
+pub fn update_name(env: Env, new_name: String) -> Result<(), TokenError>
+```
+
+**Behavior:**
+1. Verify contract is initialized by checking Admin key exists
+2. Read current admin address from storage
+3. Call `require_auth()` on admin address (panics if not authorized)
+4. Read current name from storage (defaults to "bc-forge" if not set)
+5. Write new name to storage at `DataKey::Name`
+6. Emit `upd_name` event with admin, old name, new name
+7. Return `Ok(())`
+
+#### update_symbol
+```rust
+pub fn update_symbol(env: Env, new_symbol: String) -> Result<(), TokenError>
+```
+
+**Behavior:**
+1. Verify contract is initialized by checking Admin key exists
+2. Read current admin address from storage
+3. Call `require_auth()` on admin address (panics if not authorized)
+4. Read current symbol from storage (defaults to "SFG" if not set)
+5. Write new symbol to storage at `DataKey::Symbol`
+6. Emit `upd_sym` event with admin, old symbol, new symbol
+7. Return `Ok(())`
+
+### Storage Schema
+
+Metadata is stored in instance storage using existing `DataKey` enum variants:
+
+```rust
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    // ... existing keys ...
+    Name,      // Stores the token name (String)
+    Symbol,    // Stores the token symbol (String)
+    // ... other keys ...
+}
+```
+
+**Storage Details:**
+- **Location:** Instance storage (persists across contract invocations)
+- **Key:** `DataKey::Name` for name, `DataKey::Symbol` for symbol
+- **Value Type:** `String` (Soroban SDK String type)
+- **Default Values:** Name defaults to "bc-forge", Symbol defaults to "SFG"
+- **Persistence:** Values persist indefinitely until explicitly updated
+
+## Correctness Properties
+
+### Property 1: Name Update Round-Trip
+*For any* valid name string, calling `update_name` followed by `name()` should return the same string value.
+
+### Property 2: Symbol Update Round-Trip
+*For any* valid symbol string, calling `update_symbol` followed by `symbol()` should return the same string value.
+
+### Property 3: Name Update Persistence
+*For any* valid name string, after calling `update_name`, subsequent calls to `name()` should consistently return the same updated value across multiple invocations.
+
+### Property 4: Symbol Update Persistence
+*For any* valid symbol string, after calling `update_symbol`, subsequent calls to `symbol()` should consistently return the same updated value across multiple invocations.
+
+### Property 5: Sequential Name Updates
+*For any* sequence of name strings, calling `update_name` multiple times in sequence should result in only the most recent name being stored and retrievable.
+
+### Property 6: Sequential Symbol Updates
+*For any* sequence of symbol strings, calling `update_symbol` multiple times in sequence should result in only the most recent symbol being stored and retrievable.
+
+### Property 7: Name Update Event Emission
+*For any* valid name string, calling `update_name` should emit an event with the correct structure containing the admin address, old name, and new name.
+
+### Property 8: Symbol Update Event Emission
+*For any* valid symbol string, calling `update_symbol` should emit an event with the correct structure containing the admin address, old symbol, and new symbol.
+
+### Property 9: Name Storage Preserves Special Characters
+*For any* string containing special characters, Unicode, or non-ASCII characters, calling `update_name` should store and retrieve the string without modification or sanitization.
+
+### Property 10: Symbol Storage Preserves Special Characters
+*For any* string containing special characters, Unicode, or non-ASCII characters, calling `update_symbol` should store and retrieve the string without modification or sanitization.
+
+## Error Handling
+
+### Error Cases
+
+| Condition | Error | Handling |
+|-----------|-------|----------|
+| Contract not initialized | `TokenError::NotInitialized` | Return error |
+| Caller is not admin | Authorization error | Panic via `require_auth()` |
+
+### Edge Cases
+
+- **Empty Strings:** Accepted and stored without validation
+- **Special Characters:** Stored as-is without sanitization
+- **Idempotent Updates:** Calling with same value succeeds and emits event
+- **Pause State Independence:** Updates succeed regardless of pause state
+- **Admin Transfer Integration:** New admin can immediately call update functions
+
+## Integration Points
+
+### Existing Token Contract Code
+
+- Uses existing `read_admin()` helper to retrieve current admin
+- Uses existing `ensure_initialized()` pattern
+- Uses existing `env.storage().instance()` pattern for metadata storage
+- Uses existing `env.events().publish()` pattern for event emission
+- Uses existing `TokenError` enum for error handling
+
+### Backward Compatibility
+
+- No breaking changes to existing functions
+- Existing `name()` and `symbol()` functions unchanged
+- New functions are additive only
+- Existing contracts can be upgraded to add this functionality
+
+## Testing Strategy
+
+### Unit Tests
+- Authorization tests (admin/non-admin)
+- Event emission tests
+- Edge case tests (empty strings, special characters, uninitialized contract)
+- Admin transfer integration tests
+
+### Property-Based Tests
+- 10 properties covering round-trip, persistence, sequential updates, event emission, and special character handling
+- Minimum 100 iterations per property
+
+### Integration Tests
+- Verify metadata updates don't affect balances or allowances
+- Verify sequential updates with transfers work correctly

--- a/.kiro/specs/metadata-update-functions/requirements.md
+++ b/.kiro/specs/metadata-update-functions/requirements.md
@@ -1,0 +1,155 @@
+# Requirements Document: Metadata Update Functions
+
+## Introduction
+
+This feature enables the bc-forge Token Contract to update token name and symbol after contract initialization. Token metadata updates are essential for token rebranding, correcting initialization errors, and maintaining accurate token information without requiring contract redeployment. The implementation includes admin-controlled updates, comprehensive event emission for audit trails, and integration with existing admin authorization patterns.
+
+The feature adds two new contract functions (`update_name` and `update_symbol`), with admin authentication for update operations, storage management for metadata, and comprehensive event emission for off-chain indexing.
+
+## Glossary
+
+- **Admin**: The authorized contract administrator who can execute privileged operations, including updating token metadata. Identified by the `Admin` data key in contract storage.
+- **Token_Name**: The human-readable name of the token (e.g., "Stellar Forge Token").
+- **Token_Symbol**: The short symbol representing the token (e.g., "SFG").
+- **Metadata**: Token name and symbol information stored in contract storage.
+- **Update_Event**: An event emitted when metadata is updated, containing admin address, old value, and new value.
+- **Token_Contract**: The bc-forge Token Contract implementing SEP-41 TokenInterface with metadata update capabilities.
+- **Instance_Storage**: Contract storage that persists across invocations and upgrades.
+
+## Requirements
+
+### Requirement 1: Update Name Function
+
+**User Story:** As a token administrator, I want to update the token name after initialization, so that I can rebrand the token or correct initialization errors without redeploying the contract.
+
+#### Acceptance Criteria
+
+1. WHEN the `update_name` function is called with a valid new name string, THE Token_Contract SHALL update the stored name value.
+2. WHEN the `update_name` function is called, THE Token_Contract SHALL verify that the caller is the Admin via `require_auth()`.
+3. IF the caller is not the Admin, THEN THE Token_Contract SHALL reject the call and return an authorization error.
+4. WHEN the `update_name` function succeeds, THE Token_Contract SHALL store the new name in persistent storage.
+5. WHEN the `update_name` function succeeds, THE Token_Contract SHALL emit an update event containing the admin address, old name, and new name.
+6. WHEN the `update_name` function is called with an empty string, THE Token_Contract SHALL accept and store the empty string.
+7. WHEN the `update_name` function is called on an uninitialized contract, THE Token_Contract SHALL return a `NotInitialized` error.
+
+### Requirement 2: Update Symbol Function
+
+**User Story:** As a token administrator, I want to update the token symbol after initialization, so that I can rebrand the token or correct initialization errors without redeploying the contract.
+
+#### Acceptance Criteria
+
+1. WHEN the `update_symbol` function is called with a valid new symbol string, THE Token_Contract SHALL update the stored symbol value.
+2. WHEN the `update_symbol` function is called, THE Token_Contract SHALL verify that the caller is the Admin via `require_auth()`.
+3. IF the caller is not the Admin, THEN THE Token_Contract SHALL reject the call and return an authorization error.
+4. WHEN the `update_symbol` function succeeds, THE Token_Contract SHALL store the new symbol in persistent storage.
+5. WHEN the `update_symbol` function succeeds, THE Token_Contract SHALL emit an update event containing the admin address, old symbol, and new symbol.
+6. WHEN the `update_symbol` function is called with an empty string, THE Token_Contract SHALL accept and store the empty string.
+7. WHEN the `update_symbol` function is called on an uninitialized contract, THE Token_Contract SHALL return a `NotInitialized` error.
+
+### Requirement 3: Admin Authorization
+
+**User Story:** As a token administrator, I want to ensure that only admins can update metadata, so that token branding is controlled and cannot be manipulated by regular users.
+
+#### Acceptance Criteria
+
+1. WHEN `update_name` is called by a non-admin address, THE Token_Contract SHALL reject the call and return an authorization error.
+2. WHEN `update_symbol` is called by a non-admin address, THE Token_Contract SHALL reject the call and return an authorization error.
+3. WHEN the admin is transferred via `transfer_ownership`, THE new admin SHALL be able to call `update_name` and `update_symbol` successfully.
+4. WHEN the admin is transferred via `propose_owner` and `accept_ownership`, THE new admin SHALL be able to call `update_name` and `update_symbol` after accepting.
+5. WHEN the old admin attempts to call `update_name` or `update_symbol` after ownership transfer, THE Token_Contract SHALL reject the call with an authorization error.
+
+### Requirement 4: Event Emission
+
+**User Story:** As an off-chain indexer or auditor, I want to track all metadata update operations, so that I can maintain an audit trail of token branding changes.
+
+#### Acceptance Criteria
+
+1. WHEN `update_name` succeeds, THE Token_Contract SHALL emit an event with symbol `upd_name` containing the admin address, old name, and new name.
+2. WHEN `update_symbol` succeeds, THE Token_Contract SHALL emit an event with symbol `upd_sym` containing the admin address, old symbol, and new symbol.
+3. WHEN `update_name` is called multiple times, THE Token_Contract SHALL emit a separate event for each call.
+4. WHEN `update_symbol` is called multiple times, THE Token_Contract SHALL emit a separate event for each call.
+
+### Requirement 5: Data Persistence
+
+**User Story:** As a token user, I want metadata updates to persist across contract invocations, so that the updated name and symbol are always available.
+
+#### Acceptance Criteria
+
+1. WHEN `update_name` is called and succeeds, THE updated name SHALL persist in storage and be returned by subsequent `name()` calls.
+2. WHEN `update_symbol` is called and succeeds, THE updated symbol SHALL persist in storage and be returned by subsequent `symbol()` calls.
+3. WHEN `update_name` is called multiple times, THE most recent name value SHALL be stored and retrieved.
+4. WHEN `update_symbol` is called multiple times, THE most recent symbol value SHALL be stored and retrieved.
+
+### Requirement 6: Contract Initialization State
+
+**User Story:** As a developer, I want metadata updates to only work on initialized contracts, so that the contract state is always valid.
+
+#### Acceptance Criteria
+
+1. WHEN `update_name` is called on an uninitialized contract, THE Token_Contract SHALL return a `NotInitialized` error.
+2. WHEN `update_symbol` is called on an uninitialized contract, THE Token_Contract SHALL return a `NotInitialized` error.
+
+### Requirement 7: Unit Test Coverage for Update Name
+
+**User Story:** As a developer, I want comprehensive unit tests for the `update_name` function, so that I can verify correct behavior and prevent regressions.
+
+#### Acceptance Criteria
+
+1. WHEN a unit test calls `update_name` with a valid name as the admin, THE test SHALL verify that the name is updated and persists.
+2. WHEN a unit test calls `update_name` with a non-admin address, THE test SHALL verify that an authorization error is returned.
+3. WHEN a unit test calls `update_name` with an empty string, THE test SHALL verify that the empty string is stored.
+4. WHEN a unit test calls `update_name` with a long string, THE test SHALL verify that the full string is stored without truncation.
+5. WHEN a unit test calls `update_name` on an uninitialized contract, THE test SHALL verify that a `NotInitialized` error is returned.
+6. WHEN a unit test calls `update_name` multiple times, THE test SHALL verify that only the most recent value is stored.
+7. WHEN a unit test calls `update_name` and inspects events, THE test SHALL verify that the event contains correct data.
+8. WHEN a unit test calls `update_name` while the contract is paused, THE test SHALL verify that the update succeeds.
+
+### Requirement 8: Unit Test Coverage for Update Symbol
+
+**User Story:** As a developer, I want comprehensive unit tests for the `update_symbol` function, so that I can verify correct behavior and prevent regressions.
+
+#### Acceptance Criteria
+
+1. WHEN a unit test calls `update_symbol` with a valid symbol as the admin, THE test SHALL verify that the symbol is updated and persists.
+2. WHEN a unit test calls `update_symbol` with a non-admin address, THE test SHALL verify that an authorization error is returned.
+3. WHEN a unit test calls `update_symbol` with an empty string, THE test SHALL verify that the empty string is stored.
+4. WHEN a unit test calls `update_symbol` with a long string, THE test SHALL verify that the full string is stored without truncation.
+5. WHEN a unit test calls `update_symbol` on an uninitialized contract, THE test SHALL verify that a `NotInitialized` error is returned.
+6. WHEN a unit test calls `update_symbol` multiple times, THE test SHALL verify that only the most recent value is stored.
+7. WHEN a unit test calls `update_symbol` and inspects events, THE test SHALL verify that the event contains correct data.
+8. WHEN a unit test calls `update_symbol` while the contract is paused, THE test SHALL verify that the update succeeds.
+
+### Requirement 9: Event Emission Test Coverage
+
+**User Story:** As a developer, I want to verify that metadata update events are emitted correctly, so that off-chain indexers can rely on event data.
+
+#### Acceptance Criteria
+
+1. WHEN a unit test calls `update_name` and inspects emitted events, THE test SHALL verify that an `upd_name` event is emitted with the correct admin, old name, and new name.
+2. WHEN a unit test calls `update_symbol` and inspects emitted events, THE test SHALL verify that an `upd_sym` event is emitted with the correct admin, old symbol, and new symbol.
+3. WHEN a unit test calls `update_name` multiple times, THE test SHALL verify that each call emits a separate event.
+4. WHEN a unit test calls `update_symbol` multiple times, THE test SHALL verify that each call emits a separate event.
+
+### Requirement 10: Admin Transfer Integration
+
+**User Story:** As a token administrator, I want metadata update permissions to follow admin ownership changes, so that new admins can manage token branding.
+
+#### Acceptance Criteria
+
+1. WHEN admin ownership is transferred via `transfer_ownership`, THE new admin SHALL be able to call `update_name` and `update_symbol` successfully.
+2. WHEN admin ownership is transferred via `propose_owner` and `accept_ownership`, THE new admin SHALL be able to call `update_name` and `update_symbol` after accepting.
+3. WHEN the old admin attempts to call `update_name` or `update_symbol` after ownership transfer, THE Token_Contract SHALL reject the call with an authorization error.
+4. WHEN a user has updated metadata and admin ownership is transferred, THE updated metadata SHALL persist and the new admin SHALL be able to update it further.
+
+### Requirement 11: Edge Cases and Constraints
+
+**User Story:** As a developer, I want metadata update functions to handle edge cases gracefully, so that the contract remains stable under various conditions.
+
+#### Acceptance Criteria
+
+1. WHEN `update_name` is called with special characters, Unicode, or non-ASCII characters, THE Token_Contract SHALL store and retrieve the string without modification or sanitization.
+2. WHEN `update_symbol` is called with special characters, Unicode, or non-ASCII characters, THE Token_Contract SHALL store and retrieve the string without modification or sanitization.
+3. WHEN `update_name` is called with the same value already stored, THE Token_Contract SHALL succeed and emit an event even though the value is unchanged.
+4. WHEN `update_symbol` is called with the same value already stored, THE Token_Contract SHALL succeed and emit an event even though the value is unchanged.
+5. WHEN `update_name` is called while the contract is paused, THE Token_Contract SHALL succeed (pause does not affect metadata updates).
+6. WHEN `update_symbol` is called while the contract is paused, THE Token_Contract SHALL succeed (pause does not affect metadata updates).

--- a/.kiro/specs/metadata-update-functions/tasks.md
+++ b/.kiro/specs/metadata-update-functions/tasks.md
@@ -1,0 +1,345 @@
+# Implementation Plan: Metadata Update Functions
+
+## Overview
+
+This implementation plan breaks down the metadata update functions feature into discrete, incremental coding tasks. The feature adds two new contract functions (`update_name` and `update_symbol`) to the bc-forge Token Contract, enabling authorized administrators to modify token metadata after initialization.
+
+## Tasks
+
+- [ ] 1. Set up test infrastructure and helper functions
+  - Create test setup helpers for metadata update testing
+  - Add helper functions for generating test strings (empty, ASCII, Unicode, special characters)
+  - Set up event inspection utilities for verifying event emission
+  - _Requirements: 7.1, 8.1_
+
+- [ ] 2. Implement update_name function
+  - [ ] 2.1 Implement core update_name logic
+    - Add `update_name` function to BcForgeToken contract
+    - Verify contract is initialized via `ensure_initialized()`
+    - Read current admin address from storage
+    - Call `require_auth()` on admin address for authorization
+    - Read old name from storage (default to "bc-forge")
+    - Write new name to storage at `DataKey::Name`
+    - Emit `emit_update_name` event with admin, old name, new name
+    - Return `Ok(())`
+    - _Requirements: 1.1, 1.2, 1.4_
+
+  - [ ]* 2.2 Write property test for update_name round-trip
+    - **Property 1: Name Update Round-Trip**
+    - Generate 100+ random name strings (empty, ASCII, Unicode, special characters)
+    - For each name: call `update_name`, then verify `name()` returns the same value
+    - Verify round-trip consistency across all generated inputs
+
+  - [ ]* 2.3 Write property test for name update persistence
+    - **Property 3: Name Update Persistence**
+    - Generate random name strings
+    - Call `update_name` with each name
+    - Call `name()` multiple times and verify consistent return value
+    - Verify persistence across multiple invocations
+
+  - [ ]* 2.4 Write property test for sequential name updates
+    - **Property 5: Sequential Name Updates**
+    - Generate sequences of 3-5 name strings
+    - Call `update_name` multiple times in sequence
+    - Verify only the most recent name is stored
+    - Verify previous names are overwritten
+
+  - [ ]* 2.5 Write property test for name special character preservation
+    - **Property 9: Name Storage Preserves Special Characters**
+    - Generate strings with special characters, Unicode, non-ASCII
+    - Call `update_name` with each string
+    - Verify stored value matches input exactly (no sanitization)
+    - Verify special characters are preserved
+
+- [ ] 3. Implement update_symbol function
+  - [ ] 3.1 Implement core update_symbol logic
+    - Add `update_symbol` function to BcForgeToken contract
+    - Verify contract is initialized via `ensure_initialized()`
+    - Read current admin address from storage
+    - Call `require_auth()` on admin address for authorization
+    - Read old symbol from storage (default to "SFG")
+    - Write new symbol to storage at `DataKey::Symbol`
+    - Emit `emit_update_symbol` event with admin, old symbol, new symbol
+    - Return `Ok(())`
+    - _Requirements: 2.1, 2.2, 2.4_
+
+  - [ ]* 3.2 Write property test for update_symbol round-trip
+    - **Property 2: Symbol Update Round-Trip**
+    - Generate 100+ random symbol strings (empty, ASCII, Unicode, special characters)
+    - For each symbol: call `update_symbol`, then verify `symbol()` returns the same value
+    - Verify round-trip consistency across all generated inputs
+
+  - [ ]* 3.3 Write property test for symbol update persistence
+    - **Property 4: Symbol Update Persistence**
+    - Generate random symbol strings
+    - Call `update_symbol` with each symbol
+    - Call `symbol()` multiple times and verify consistent return value
+    - Verify persistence across multiple invocations
+
+  - [ ]* 3.4 Write property test for sequential symbol updates
+    - **Property 6: Sequential Symbol Updates**
+    - Generate sequences of 3-5 symbol strings
+    - Call `update_symbol` multiple times in sequence
+    - Verify only the most recent symbol is stored
+    - Verify previous symbols are overwritten
+
+  - [ ]* 3.5 Write property test for symbol special character preservation
+    - **Property 10: Symbol Storage Preserves Special Characters**
+    - Generate strings with special characters, Unicode, non-ASCII
+    - Call `update_symbol` with each string
+    - Verify stored value matches input exactly (no sanitization)
+    - Verify special characters are preserved
+
+- [ ] 4. Checkpoint - Verify core implementation and property tests pass
+  - Run all property-based tests for update_name and update_symbol
+  - Verify all 10 property tests pass with 100+ iterations each
+  - Ensure no panics or unexpected errors
+
+- [ ] 5. Write unit tests for authorization
+  - [ ] 5.1 Write unit test for admin can update name
+    - Admin calls `update_name` with valid new name
+    - Verify function returns `Ok(())`
+    - Verify `name()` returns updated value
+    - _Requirements: 1.1, 1.2, 3.1_
+
+  - [ ] 5.2 Write unit test for non-admin cannot update name
+    - Non-admin address calls `update_name`
+    - Verify authorization error is returned
+    - Verify name is not changed
+    - _Requirements: 1.3, 3.1_
+
+  - [ ] 5.3 Write unit test for admin can update symbol
+    - Admin calls `update_symbol` with valid new symbol
+    - Verify function returns `Ok(())`
+    - Verify `symbol()` returns updated value
+    - _Requirements: 2.1, 2.2, 3.2_
+
+  - [ ] 5.4 Write unit test for non-admin cannot update symbol
+    - Non-admin address calls `update_symbol`
+    - Verify authorization error is returned
+    - Verify symbol is not changed
+    - _Requirements: 2.3, 3.2_
+
+- [ ] 6. Write unit tests for event emission
+  - [ ] 6.1 Write unit test for update_name event emission
+    - Admin calls `update_name` with new name
+    - Inspect emitted events
+    - Verify `upd_name` event is emitted
+    - Verify event contains correct admin, old name, new name
+    - _Requirements: 1.4, 4.1, 9.1_
+
+  - [ ] 6.2 Write unit test for update_symbol event emission
+    - Admin calls `update_symbol` with new symbol
+    - Inspect emitted events
+    - Verify `upd_sym` event is emitted
+    - Verify event contains correct admin, old symbol, new symbol
+    - _Requirements: 2.4, 4.2, 9.2_
+
+  - [ ] 6.3 Write unit test for multiple update_name events
+    - Admin calls `update_name` multiple times with different names
+    - Inspect emitted events
+    - Verify separate event emitted for each call
+    - Verify each event has correct data
+    - _Requirements: 4.3, 9.3_
+
+  - [ ] 6.4 Write unit test for multiple update_symbol events
+    - Admin calls `update_symbol` multiple times with different symbols
+    - Inspect emitted events
+    - Verify separate event emitted for each call
+    - Verify each event has correct data
+    - _Requirements: 4.4, 9.4_
+
+- [ ] 7. Write unit tests for edge cases
+  - [ ] 7.1 Write unit test for update_name with empty string
+    - Admin calls `update_name` with empty string
+    - Verify function returns `Ok(())`
+    - Verify `name()` returns empty string
+    - _Requirements: 1.6, 7.4_
+
+  - [ ] 7.2 Write unit test for update_symbol with empty string
+    - Admin calls `update_symbol` with empty string
+    - Verify function returns `Ok(())`
+    - Verify `symbol()` returns empty string
+    - _Requirements: 2.6, 8.4_
+
+  - [ ] 7.3 Write unit test for update_name with long string
+    - Admin calls `update_name` with very long string (1000+ characters)
+    - Verify function returns `Ok(())`
+    - Verify `name()` returns full string without truncation
+    - _Requirements: 7.5_
+
+  - [ ] 7.4 Write unit test for update_symbol with long string
+    - Admin calls `update_symbol` with very long string (1000+ characters)
+    - Verify function returns `Ok(())`
+    - Verify `symbol()` returns full string without truncation
+    - _Requirements: 8.5_
+
+  - [ ] 7.5 Write unit test for update_name on uninitialized contract
+    - Call `update_name` on uninitialized contract
+    - Verify `NotInitialized` error is returned
+    - _Requirements: 6.1, 7.7_
+
+  - [ ] 7.6 Write unit test for update_symbol on uninitialized contract
+    - Call `update_symbol` on uninitialized contract
+    - Verify `NotInitialized` error is returned
+    - _Requirements: 6.2, 8.7_
+
+  - [ ] 7.7 Write unit test for idempotent name update
+    - Admin calls `update_name` with same value already stored
+    - Verify function returns `Ok(())`
+    - Verify event is emitted even though value unchanged
+    - _Requirements: 11.3_
+
+  - [ ] 7.8 Write unit test for idempotent symbol update
+    - Admin calls `update_symbol` with same value already stored
+    - Verify function returns `Ok(())`
+    - Verify event is emitted even though value unchanged
+    - _Requirements: 11.4_
+
+  - [ ] 7.9 Write unit test for update_name while paused
+    - Pause the contract
+    - Admin calls `update_name`
+    - Verify function succeeds (pause doesn't affect metadata updates)
+    - Verify name is updated
+    - _Requirements: 11.5_
+
+  - [ ] 7.10 Write unit test for update_symbol while paused
+    - Pause the contract
+    - Admin calls `update_symbol`
+    - Verify function succeeds (pause doesn't affect metadata updates)
+    - Verify symbol is updated
+    - _Requirements: 11.6_
+
+- [ ] 8. Write unit tests for admin transfer integration
+  - [ ] 8.1 Write unit test for new admin can update name after transfer_ownership
+    - Transfer ownership via `transfer_ownership` to new admin
+    - New admin calls `update_name`
+    - Verify function returns `Ok(())`
+    - Verify name is updated
+    - _Requirements: 3.3, 10.1_
+
+  - [ ] 8.2 Write unit test for new admin can update symbol after transfer_ownership
+    - Transfer ownership via `transfer_ownership` to new admin
+    - New admin calls `update_symbol`
+    - Verify function returns `Ok(())`
+    - Verify symbol is updated
+    - _Requirements: 3.3, 10.2_
+
+  - [ ] 8.3 Write unit test for old admin cannot update name after transfer
+    - Transfer ownership to new admin
+    - Old admin attempts to call `update_name`
+    - Verify authorization error is returned
+    - _Requirements: 3.1, 10.5_
+
+  - [ ] 8.4 Write unit test for old admin cannot update symbol after transfer
+    - Transfer ownership to new admin
+    - Old admin attempts to call `update_symbol`
+    - Verify authorization error is returned
+    - _Requirements: 3.2, 10.6_
+
+  - [ ] 8.5 Write unit test for new admin can update name after propose_owner/accept_ownership
+    - Propose new admin via `propose_owner`
+    - New admin accepts via `accept_ownership`
+    - New admin calls `update_name`
+    - Verify function returns `Ok(())`
+    - Verify name is updated
+    - _Requirements: 3.4, 10.3_
+
+  - [ ] 8.6 Write unit test for new admin can update symbol after propose_owner/accept_ownership
+    - Propose new admin via `propose_owner`
+    - New admin accepts via `accept_ownership`
+    - New admin calls `update_symbol`
+    - Verify function returns `Ok(())`
+    - Verify symbol is updated
+    - _Requirements: 3.4, 10.4_
+
+- [ ] 9. Checkpoint - Ensure all unit tests pass
+  - Run all unit tests for authorization, event emission, edge cases, and admin transfer
+  - Verify all tests pass without errors
+  - Verify test coverage includes all acceptance criteria
+
+- [ ] 10. Write property-based tests for event emission
+  - [ ] 10.1 Write property test for name update event emission
+    - **Property 7: Name Update Event Emission**
+    - Generate 100+ random name strings
+    - For each name: call `update_name` and inspect events
+    - Verify `upd_name` event is emitted with correct structure
+    - Verify event contains admin, old name, new name
+
+  - [ ] 10.2 Write property test for symbol update event emission
+    - **Property 8: Symbol Update Event Emission**
+    - Generate 100+ random symbol strings
+    - For each symbol: call `update_symbol` and inspect events
+    - Verify `upd_sym` event is emitted with correct structure
+    - Verify event contains admin, old symbol, new symbol
+
+- [ ] 11. Write integration tests
+  - [ ] 11.1 Write integration test for name update does not affect balances
+    - Initialize contract with admin and mint tokens to users
+    - Admin calls `update_name`
+    - Verify user balances are unchanged
+    - Verify supply is unchanged
+
+  - [ ] 11.2 Write integration test for symbol update does not affect balances
+    - Initialize contract with admin and mint tokens to users
+    - Admin calls `update_symbol`
+    - Verify user balances are unchanged
+    - Verify supply is unchanged
+
+  - [ ] 11.3 Write integration test for name update does not affect allowances
+    - Initialize contract and set up allowances
+    - Admin calls `update_name`
+    - Verify allowances are unchanged
+
+  - [ ] 11.4 Write integration test for symbol update does not affect allowances
+    - Initialize contract and set up allowances
+    - Admin calls `update_symbol`
+    - Verify allowances are unchanged
+
+  - [ ] 11.5 Write integration test for sequential metadata updates with transfers
+    - Initialize contract
+    - Admin updates name
+    - Users perform transfers
+    - Admin updates symbol
+    - Verify all operations succeed and state is consistent
+
+- [ ] 12. Checkpoint - Ensure all property-based and integration tests pass
+  - Run all property-based tests (10 properties with 100+ iterations each)
+  - Run all integration tests
+  - Verify no panics or unexpected errors
+  - Verify all requirements are covered by tests
+
+- [ ] 13. Update documentation
+  - [ ] 13.1 Add update_name function documentation
+    - Add rustdoc comments to `update_name` function
+    - Document parameters, return values, and behavior
+    - Include examples of usage
+    - Document authorization requirements
+
+  - [ ] 13.2 Add update_symbol function documentation
+    - Add rustdoc comments to `update_symbol` function
+    - Document parameters, return values, and behavior
+    - Include examples of usage
+    - Document authorization requirements
+
+  - [ ] 13.3 Update contract README with metadata update feature
+    - Add section describing metadata update functions
+    - Document use cases for token rebranding
+    - Include event emission details
+    - Document authorization model
+
+- [ ] 14. Final checkpoint - Ensure all tests pass and documentation is complete
+  - Run full test suite (unit tests, property tests, integration tests)
+  - Verify all 10 property tests pass with 100+ iterations each
+  - Verify all unit tests pass
+  - Verify all integration tests pass
+  - Verify documentation is complete and accurate
+
+## Notes
+
+- Tasks marked with `*` are optional property-based tests and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property tests validate universal correctness properties across many generated inputs
+- Unit tests validate specific examples and edge cases
+- Integration tests verify interactions with other contract functions
+- All tests use snapshot testing pattern consistent with existing token contract tests

--- a/.kiro/specs/token-locking-vesting/.config.kiro
+++ b/.kiro/specs/token-locking-vesting/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d094a61f-2bda-41c1-8a9f-bdc338b59833", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/token-locking-vesting/design.md
+++ b/.kiro/specs/token-locking-vesting/design.md
@@ -1,0 +1,257 @@
+# Design Document: Token Locking and Vesting Capabilities
+
+## Overview
+
+The token locking and vesting feature extends the bc-forge Token Contract with time-based token locking capabilities. This design enables administrators to lock tokens for specified durations, preventing transfers until unlock times are reached. Users can then withdraw their unlocked tokens after the lock period expires.
+
+### Key Design Principles
+
+1. **Separation of Concerns**: Locked tokens are stored separately from available balances
+2. **Admin Control**: Only administrators can initiate token locks
+3. **User Autonomy**: Users can withdraw their own expired locked tokens
+4. **Time-Based Enforcement**: Lock expiration determined by comparing ledger timestamps
+5. **Backward Compatibility**: Existing transfer functions enhanced to respect locked amounts
+6. **Audit Trail**: All lock and withdrawal operations emit events
+
+## Architecture
+
+### High-Level Flow
+
+```
+Admin initiates lock_tokens(user, amount, unlock_time)
+  ├─→ Verify admin authorization
+  ├─→ Validate amount > 0 and <= available balance
+  ├─→ Deduct from user's available balance
+  ├─→ Store/accumulate in LockupInfo
+  ├─→ Emit lock event
+  └─→ Return success
+
+User calls withdraw_locked() after unlock_time
+  ├─→ Verify user authorization
+  ├─→ Check if lock exists
+  ├─→ Verify current_timestamp >= unlock_time
+  ├─→ Restore locked amount to available balance
+  ├─→ Remove lock from storage
+  ├─→ Emit withdraw event
+  └─→ Return success
+
+Transfer functions check locked amounts
+  ├─→ Calculate available_balance = total - locked
+  ├─→ Verify transfer_amount <= available_balance
+  └─→ Proceed with transfer or return error
+```
+
+### Storage Architecture
+
+```
+DataKey::Lockup(Address) → LockupInfo {
+    amount: i128,           // Total accumulated locked amount
+    unlock_time: u64        // Maximum unlock timestamp (seconds)
+}
+```
+
+**Storage Characteristics**:
+- **Scope**: Persistent storage (survives contract upgrades)
+- **Key Format**: `Lockup(user_address)` - one entry per user
+- **Lifetime**: Created on first lock, removed on withdrawal
+- **Accumulation**: Multiple locks accumulate amounts and use maximum unlock time
+
+### Balance Calculation Model
+
+```
+total_balance = available_balance + locked_balance
+
+Where:
+  available_balance = balance stored in Balance(user) data key
+  locked_balance = lockup_info.amount (if lock exists)
+  
+For transfer operations:
+  max_transferable = available_balance (excludes locked_balance)
+```
+
+## Components and Interfaces
+
+### LockupInfo Structure
+
+```rust
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct LockupInfo {
+    pub amount: i128,           // Total accumulated locked amount
+    pub unlock_time: u64,       // Maximum unlock timestamp (seconds since epoch)
+}
+```
+
+### Function Signatures
+
+#### lock_tokens
+```rust
+pub fn lock_tokens(
+    env: Env,
+    user: Address,
+    amount: i128,
+    unlock_time: u64,
+) -> Result<(), TokenError>
+```
+
+**Behavior:**
+1. Verify contract is initialized
+2. Verify caller is admin via `require_auth()`
+3. Validate amount > 0
+4. Validate amount <= user's available balance
+5. Deduct amount from user's available balance
+6. Create or update LockupInfo: accumulate amount, use maximum unlock_time
+7. Store updated LockupInfo in persistent storage
+8. Emit lock event with user, amount, and unlock_time
+9. Return `Ok(())`
+
+#### withdraw_locked
+```rust
+pub fn withdraw_locked(env: Env, user: Address)
+```
+
+**Behavior:**
+1. Verify contract is initialized
+2. Verify caller is the user via `require_auth()`
+3. Read LockupInfo from storage (panic if not found)
+4. Verify current ledger timestamp >= unlock_time (panic if not)
+5. Add locked amount back to user's available balance
+6. Remove LockupInfo from persistent storage
+7. Emit withdraw event with user and withdrawn amount
+
+### Helper Functions
+
+```rust
+// Read locked amount for a user (returns 0 if no lock exists)
+fn get_locked_amount(env: &Env, user: &Address) -> i128
+
+// Check if tokens are still locked
+fn is_locked(env: &Env, user: &Address) -> bool
+
+// Read/write/remove lockup info
+fn read_lockup(env: &Env, user: &Address) -> Option<LockupInfo>
+fn write_lockup(env: &Env, user: &Address, lockup: LockupInfo)
+fn remove_lockup(env: &Env, user: &Address)
+```
+
+## Correctness Properties
+
+### Property 1: Lock Deducts from Available Balance
+*For any* user with available balance and any valid lock amount, calling `lock_tokens` SHALL reduce the user's available balance by exactly the locked amount.
+
+### Property 2: Lock Accumulation
+*For any* sequence of `lock_tokens` calls for the same user with varying amounts, the total locked amount SHALL equal the sum of all individual lock amounts.
+
+### Property 3: Unlock Time Maximization
+*For any* sequence of `lock_tokens` calls for the same user with varying unlock times, the stored unlock time SHALL be the maximum of all provided unlock times.
+
+### Property 4: Lock Storage Persistence
+*For any* successful `lock_tokens` call, the locked amount and unlock time SHALL be stored in persistent storage and remain accessible until `withdraw_locked` is called.
+
+### Property 5: Lock Event Emission
+*For any* successful `lock_tokens` call, an event with symbol "locked" SHALL be emitted containing the user address, locked amount, and unlock time.
+
+### Property 6: Transfer Prevention for Locked Amounts
+*For any* user with locked tokens and any transfer amount greater than their available balance, the transfer operation SHALL fail with `InsufficientBalance` error.
+
+### Property 7: Available Balance Calculation
+*For any* user with locked tokens, the available balance for transfers SHALL equal the total balance minus the locked amount.
+
+### Property 8: Locked Tokens Remain Locked Until Withdrawal
+*For any* user with locked tokens where current timestamp < unlock_time, the locked tokens SHALL NOT be transferable and SHALL remain in locked storage.
+
+### Property 9: Withdrawal Eligibility at Unlock Time
+*For any* user with locked tokens where current timestamp >= unlock_time, calling `withdraw_locked` SHALL succeed and restore the locked amount to available balance.
+
+### Property 10: Withdrawal Removes Lock Storage
+*For any* successful `withdraw_locked` call, the lock information SHALL be removed from persistent storage and subsequent calls to `withdraw_locked` SHALL fail.
+
+### Property 11: Withdrawal Event Emission
+*For any* successful `withdraw_locked` call, an event with symbol "unlock" SHALL be emitted containing the user address and the total withdrawn amount.
+
+### Property 12: Partial Lock Leaves Remainder Transferable
+*For any* user with total balance B and partial lock amount L where L < B, the remaining balance (B - L) SHALL be transferable while the locked amount remains locked.
+
+### Property 13: Clawback Respects Locked Amounts
+*For any* user with locked tokens and clawback amount C where C <= available balance, the clawback operation SHALL succeed and locked tokens SHALL remain unchanged.
+
+### Property 14: Withdrawal Requires User Authorization
+*For any* `withdraw_locked` call, the operation SHALL succeed only if the caller is the user (verified via `require_auth()`).
+
+### Property 15: Lock Requires Admin Authorization
+*For any* `lock_tokens` call, the operation SHALL succeed only if the caller is the admin (verified via `require_auth()`).
+
+### Property 16: Admin Transfer Preserves Locking Authority
+*For any* admin ownership transfer, the new admin SHALL be able to call `lock_tokens` successfully and the old admin SHALL NOT be able to call `lock_tokens`.
+
+### Property 17: Balance Includes Locked Tokens
+*For any* user with locked tokens, the `balance()` function SHALL return the total balance (locked + available).
+
+### Property 18: Lock Operations Work During Pause
+*For any* paused contract, the `lock_tokens` function SHALL still be callable by the admin and `withdraw_locked` SHALL still be callable by users with expired locks.
+
+### Property 19: Multiple Withdrawals Fail After First
+*For any* user who successfully calls `withdraw_locked`, a subsequent call to `withdraw_locked` SHALL fail because the lock information has been removed.
+
+### Property 20: Unlock Time Monotonicity
+*For any* sequence of `lock_tokens` calls for the same user, the stored unlock_time SHALL never decrease—it SHALL always be the maximum of all provided unlock times.
+
+## Error Handling
+
+### Error Cases
+
+| Condition | Error | Handling |
+|-----------|-------|----------|
+| Contract not initialized | `TokenError::NotInitialized` | Return error |
+| Caller is not admin | Authorization error | Panic via `require_auth()` |
+| Amount <= 0 | `TokenError::InvalidAmount` | Return error |
+| Amount > available balance | `TokenError::InsufficientBalance` | Return error |
+| Caller is not the user | Authorization error | Panic via `require_auth()` |
+| No lock exists for user | Panic | Panic with descriptive message |
+| Current timestamp < unlock_time | Panic | Panic with "tokens are still locked" message |
+
+## Integration Points
+
+### Existing Transfer Functions
+
+**Modified Functions**:
+- `transfer()`: Check available balance (total - locked)
+- `transfer_from()`: Check available balance (total - locked)
+- `burn()`: Check available balance (total - locked)
+- `burn_from()`: Check available balance (total - locked)
+- `clawback()`: Clawback from available balance only
+
+### Admin Management
+
+`lock_tokens` uses existing admin verification via `Self::read_admin()` and `require_auth()`. Admin transfers automatically grant locking authority to the new admin.
+
+### Pause State
+
+`lock_tokens` and `withdraw_locked` do NOT check pause state. Transfer functions continue to respect pause state.
+
+### Contract Upgrade
+
+Lock information stored in persistent storage automatically persists across contract upgrades.
+
+## Testing Strategy
+
+### Unit Tests
+- Valid lock/withdrawal scenarios
+- Authorization tests (admin/non-admin)
+- Insufficient balance and invalid amount tests
+- Event emission tests
+- Multiple locks and accumulation tests
+- Admin transfer integration tests
+- Pause state integration tests
+- Edge case tests
+
+### Property-Based Tests
+- 20 properties covering all correctness requirements
+- Minimum 100 iterations per property
+
+### Integration Tests
+- Complete lock-withdraw cycles
+- Multiple lock tranches
+- Clawback with locked tokens
+- Admin transfer with locked tokens
+- Pause state with locked tokens

--- a/.kiro/specs/token-locking-vesting/requirements.md
+++ b/.kiro/specs/token-locking-vesting/requirements.md
@@ -1,0 +1,188 @@
+# Requirements Document: Token Locking and Vesting Capabilities
+
+## Introduction
+
+This feature enables the bc-forge Token Contract to lock tokens for a specified duration, preventing locked tokens from being transferred until the lock period expires. Token locking is essential for vesting schedules, token release mechanisms, and preventing token transfers during certain periods.
+
+The feature adds two new contract functions (`lock_tokens` and `withdraw_locked`), with admin authentication for locking operations, time-based unlock validation, and integration with the existing balance and transfer mechanisms to prevent locked token transfers.
+
+## Glossary
+
+- **Admin**: The authorized contract administrator who can execute privileged operations, including locking tokens.
+- **Lock_Period**: The duration for which tokens are locked, specified as an unlock timestamp (seconds since epoch).
+- **Locked_Tokens**: Tokens that have been locked and cannot be transferred until the lock period expires.
+- **Unlock_Time**: The timestamp (in seconds) at which locked tokens become available for withdrawal.
+- **LockupInfo**: A data structure containing the locked amount and unlock timestamp for a user.
+- **Available_Balance**: The balance of tokens that are not locked and can be freely transferred.
+- **Locked_Balance**: The balance of tokens that are locked and cannot be transferred.
+- **Vesting_Schedule**: A time-based release mechanism where tokens become available at a specified unlock time.
+
+## Requirements
+
+### Requirement 1: Lock Tokens Function
+
+**User Story:** As a token administrator, I want to lock tokens for a user for a specified duration, so that I can implement vesting schedules and prevent token transfers during lock periods.
+
+#### Acceptance Criteria
+
+1. WHEN the `lock_tokens` function is called with a valid user address, amount, and unlock time, THE Token_Contract SHALL deduct the amount from the user's available balance.
+2. WHEN the `lock_tokens` function is called, THE Token_Contract SHALL verify that the caller is the Admin via `require_auth()`.
+3. IF the caller is not the Admin, THEN THE Token_Contract SHALL reject the call and return an authorization error.
+4. WHEN the `lock_tokens` function is called with an amount greater than the user's available balance, THE Token_Contract SHALL return an `InsufficientBalance` error.
+5. WHEN the `lock_tokens` function is called with an amount less than or equal to zero, THE Token_Contract SHALL return an `InvalidAmount` error.
+6. WHEN the `lock_tokens` function succeeds, THE Token_Contract SHALL store the locked amount and unlock time in persistent storage under the user's address.
+7. WHEN the `lock_tokens` function succeeds, THE Token_Contract SHALL emit a lock event containing the user address, locked amount, and unlock time.
+8. WHEN the `lock_tokens` function is called on an uninitialized contract, THE Token_Contract SHALL return a `NotInitialized` error.
+
+### Requirement 2: Locked Token Storage Management
+
+**User Story:** As a developer, I want locked tokens to be stored separately from available balances, so that the contract can distinguish between transferable and non-transferable tokens.
+
+#### Acceptance Criteria
+
+1. WHEN tokens are locked via `lock_tokens`, THE Token_Contract SHALL store the lock information in persistent storage using the `Lockup(Address)` data key.
+2. WHEN `lock_tokens` is called for a user with no existing lock, THE Token_Contract SHALL create a new LockupInfo structure with the locked amount and unlock time.
+3. WHEN `lock_tokens` is called for a user with an existing lock, THE Token_Contract SHALL add the new locked amount to the existing locked amount.
+4. WHEN `lock_tokens` is called for a user with an existing lock and a later unlock time, THE Token_Contract SHALL update the unlock time to the later value.
+5. WHEN `lock_tokens` is called for a user with an existing lock and an earlier unlock time, THE Token_Contract SHALL keep the existing (later) unlock time.
+6. WHEN a user's locked tokens are withdrawn, THE Token_Contract SHALL remove the lock information from persistent storage.
+7. THE LockupInfo structure SHALL contain exactly two fields: `amount` (i128) and `unlock_time` (u64).
+
+### Requirement 3: Prevent Transfers of Locked Tokens
+
+**User Story:** As a token holder, I want to ensure that locked tokens cannot be transferred, so that vesting schedules are enforced and tokens remain locked until the unlock time.
+
+#### Acceptance Criteria
+
+1. WHEN a user attempts to transfer tokens via the `transfer` function, THE Token_Contract SHALL check if the user has locked tokens.
+2. WHEN a user attempts to transfer an amount greater than their available balance (excluding locked tokens), THE Token_Contract SHALL return an `InsufficientBalance` error.
+3. WHEN a user attempts to transfer tokens via `transfer_from`, THE Token_Contract SHALL check if the source user has locked tokens.
+4. WHEN a user attempts to transfer an amount via `transfer_from` greater than the source user's available balance, THE Token_Contract SHALL return an `InsufficientBalance` error.
+5. WHEN a user's locked tokens are still locked (current timestamp < unlock time), THE locked tokens SHALL NOT be included in the available balance for transfer calculations.
+6. WHEN a user's locked tokens have expired (current timestamp >= unlock time), THE locked tokens SHALL remain locked until explicitly withdrawn via `withdraw_locked`.
+7. WHEN a user has both locked and available tokens, THE `balance` function SHALL return the total balance (locked + available).
+8. WHERE a user has locked tokens, THE available balance for transfers SHALL be calculated as total balance minus locked amount.
+
+### Requirement 4: Withdraw Locked Tokens Function
+
+**User Story:** As a token holder, I want to withdraw my locked tokens after the lock period expires, so that I can access my vested tokens.
+
+#### Acceptance Criteria
+
+1. WHEN the `withdraw_locked` function is called by a user with expired locked tokens, THE Token_Contract SHALL add the locked amount back to the user's available balance.
+2. WHEN the `withdraw_locked` function is called, THE Token_Contract SHALL verify that the caller is the user via `require_auth()`.
+3. IF the user has no locked tokens, THEN THE Token_Contract SHALL return an error or panic with a descriptive message.
+4. WHEN the `withdraw_locked` function is called and the current timestamp is less than the unlock time, THE Token_Contract SHALL panic with a message indicating tokens are still locked.
+5. WHEN the `withdraw_locked` function succeeds, THE Token_Contract SHALL remove the lock information from persistent storage.
+6. WHEN the `withdraw_locked` function succeeds, THE Token_Contract SHALL emit a withdraw event containing the user address and withdrawn amount.
+7. WHEN the `withdraw_locked` function is called on an uninitialized contract, THE Token_Contract SHALL return a `NotInitialized` error.
+
+### Requirement 5: Lock Expiration and Time-Based Validation
+
+**User Story:** As a token administrator, I want lock periods to be enforced based on ledger timestamps, so that vesting schedules are deterministic and verifiable.
+
+#### Acceptance Criteria
+
+1. WHEN `lock_tokens` is called with an unlock time, THE Token_Contract SHALL store the unlock time as a u64 timestamp (seconds since epoch).
+2. WHEN `withdraw_locked` is called, THE Token_Contract SHALL compare the current ledger timestamp against the stored unlock time.
+3. WHEN the current ledger timestamp is less than the unlock time, THE Token_Contract SHALL prevent withdrawal and panic with a descriptive message.
+4. WHEN the current ledger timestamp is greater than or equal to the unlock time, THE Token_Contract SHALL allow withdrawal.
+5. WHEN `lock_tokens` is called with an unlock time in the past, THE Token_Contract SHALL accept the operation (no validation of unlock time value).
+6. WHERE an unlock time is in the past, THE user SHALL be able to immediately call `withdraw_locked` to retrieve the tokens.
+
+### Requirement 6: Multiple Locks and Partial Locks
+
+**User Story:** As a token administrator, I want to support multiple lock operations for the same user, so that I can implement complex vesting schedules with multiple tranches.
+
+#### Acceptance Criteria
+
+1. WHEN `lock_tokens` is called multiple times for the same user with different amounts, THE Token_Contract SHALL accumulate the locked amounts.
+2. WHEN `lock_tokens` is called multiple times for the same user with different unlock times, THE Token_Contract SHALL use the latest (maximum) unlock time.
+3. WHEN a user has accumulated locked tokens from multiple lock operations, THE `withdraw_locked` function SHALL withdraw all accumulated locked tokens at once.
+4. WHEN `lock_tokens` is called with a partial amount of a user's balance, THE Token_Contract SHALL lock only the specified amount and leave the remainder available for transfer.
+5. WHEN a user has both locked and available tokens, THE user SHALL be able to transfer the available tokens while the locked tokens remain locked.
+6. WHEN `lock_tokens` is called multiple times with different unlock times, THE Token_Contract SHALL use the maximum unlock time for withdrawal eligibility.
+
+### Requirement 7: Admin-Only Locking
+
+**User Story:** As a token administrator, I want to ensure that only admins can lock tokens, so that vesting schedules are controlled and cannot be manipulated by regular users.
+
+#### Acceptance Criteria
+
+1. WHEN `lock_tokens` is called by a non-admin address, THE Token_Contract SHALL reject the call and return an authorization error.
+2. WHEN the admin is transferred via `transfer_ownership`, THE new admin SHALL be able to call `lock_tokens` successfully.
+3. WHEN the admin is transferred via `propose_owner` and `accept_ownership`, THE new admin SHALL be able to call `lock_tokens` after accepting.
+4. WHEN the old admin attempts to call `lock_tokens` after ownership transfer, THE Token_Contract SHALL reject the call with an authorization error.
+5. WHERE a user has locked tokens, THE user SHALL be able to call `withdraw_locked` to retrieve expired tokens (no admin authorization required for withdrawal).
+
+### Requirement 8: Lock Event Emission
+
+**User Story:** As an off-chain indexer or auditor, I want to track all token locking operations, so that I can maintain an audit trail of vesting schedules and token locks.
+
+#### Acceptance Criteria
+
+1. WHEN `lock_tokens` succeeds, THE Token_Contract SHALL emit an event with symbol `locked` containing the user address, locked amount, and unlock time.
+2. WHEN `withdraw_locked` succeeds, THE Token_Contract SHALL emit an event with symbol `withdraw_locked` containing the user address and withdrawn amount.
+3. WHEN `lock_tokens` is called multiple times for the same user, THE Token_Contract SHALL emit a separate event for each lock operation.
+4. WHEN `withdraw_locked` is called, THE Token_Contract SHALL emit an event containing the total withdrawn amount (all accumulated locked tokens).
+5. THE lock event data SHALL include the user address, locked amount, and unlock time for audit purposes.
+6. THE withdraw event data SHALL include the user address and withdrawn amount for audit purposes.
+
+### Requirement 9: Integration with Existing Transfer Mechanisms
+
+**User Story:** As a token user, I want locked tokens to be properly integrated with existing transfer functions, so that the contract enforces lock constraints consistently.
+
+#### Acceptance Criteria
+
+1. WHEN a user calls `transfer` with locked tokens, THE Token_Contract SHALL calculate available balance as total balance minus locked amount.
+2. WHEN a user calls `transfer_from` with locked tokens, THE Token_Contract SHALL calculate available balance as total balance minus locked amount.
+3. WHEN a user calls `burn` with locked tokens, THE Token_Contract SHALL calculate available balance as total balance minus locked amount.
+4. WHEN a user calls `burn_from` with locked tokens, THE Token_Contract SHALL calculate available balance as total balance minus locked amount.
+5. WHEN a user has locked tokens and calls `balance`, THE Token_Contract SHALL return the total balance (locked + available).
+6. WHEN a user has locked tokens and calls `transfer` with an amount equal to their available balance, THE Token_Contract SHALL succeed and transfer only the available tokens.
+7. WHEN a user has locked tokens and calls `transfer` with an amount greater than their available balance, THE Token_Contract SHALL return an `InsufficientBalance` error.
+
+### Requirement 10: Clawback Integration with Locked Tokens
+
+**User Story:** As a token administrator with clawback authority, I want to clawback tokens including locked tokens, so that regulatory requirements can be enforced.
+
+#### Acceptance Criteria
+
+1. WHEN the `clawback` function is called on a user with locked tokens, THE Token_Contract SHALL clawback from the available balance first.
+2. WHEN the `clawback` function is called with an amount greater than the available balance but less than total balance, THE Token_Contract SHALL return an `InsufficientBalance` error.
+3. WHEN the `clawback` function is called with an amount less than or equal to the available balance, THE Token_Contract SHALL succeed and clawback only from available tokens.
+4. WHERE clawback is called on a user with locked tokens, THE locked tokens SHALL remain locked and not be affected by the clawback operation.
+
+### Requirement 11: Pause State and Locked Tokens
+
+**User Story:** As a token administrator, I want lock and withdrawal operations to work independently of pause state, so that vesting schedules are not affected by contract pause operations.
+
+#### Acceptance Criteria
+
+1. WHEN the contract is paused, THE `lock_tokens` function SHALL still be callable by the admin.
+2. WHEN the contract is paused, THE `withdraw_locked` function SHALL still be callable by users with expired locked tokens.
+3. WHEN the contract is paused, THE `transfer` function SHALL reject transfers (including transfers of available tokens from users with locked tokens).
+4. WHEN the contract is paused, THE `balance` function SHALL still return the total balance including locked tokens.
+
+### Requirement 12: Edge Cases and Constraints
+
+**User Story:** As a developer, I want the locking functions to handle edge cases gracefully, so that the contract remains stable under various conditions.
+
+#### Acceptance Criteria
+
+1. WHEN `lock_tokens` is called with an unlock time equal to the current ledger timestamp, THE Token_Contract SHALL accept the operation and allow immediate withdrawal.
+2. WHEN `lock_tokens` is called with a very large unlock time (far in the future), THE Token_Contract SHALL accept and store the value without overflow.
+3. WHEN `lock_tokens` is called with an unlock time of zero, THE Token_Contract SHALL accept the operation (no validation of unlock time value).
+4. WHEN a user has locked tokens and the contract is upgraded, THE locked tokens and lock information SHALL persist across the upgrade.
+5. WHEN `lock_tokens` is called for the same user multiple times in rapid succession, THE Token_Contract SHALL accumulate amounts and use the maximum unlock time.
+6. WHEN `withdraw_locked` is called multiple times by the same user, THE second call SHALL fail because the lock information has been removed after the first withdrawal.
+7. WHEN `lock_tokens` is called with an amount that would cause integer overflow in the locked amount, THE Token_Contract SHALL handle the overflow gracefully (panic or return error).
+
+## Test Coverage Requirements
+
+- Comprehensive unit tests for lock_tokens and withdraw_locked functions
+- Transfer prevention tests to verify locked tokens cannot be transferred
+- Event emission tests to verify correct event data
+- Admin transfer integration tests
+- Property-based tests for lock accumulation, transfer prevention, and time-based unlock
+- Integration tests for complete lock-withdraw cycles and multiple tranches

--- a/.kiro/specs/token-locking-vesting/tasks.md
+++ b/.kiro/specs/token-locking-vesting/tasks.md
@@ -1,0 +1,316 @@
+# Implementation Plan: Token Locking and Vesting Capabilities
+
+## Overview
+
+This implementation plan breaks down the token locking and vesting feature into discrete, manageable coding tasks. The feature adds time-based token locking capabilities to the bc-forge Token Contract, enabling administrators to lock tokens for specified durations and users to withdraw unlocked tokens after the lock period expires.
+
+## Tasks
+
+### Phase 1: Storage Schema and Helper Functions
+
+- [ ] 1. Implement helper functions for lock management
+  - Implement `get_locked_amount()` to retrieve locked amount for a user (returns 0 if no lock exists)
+  - Implement `is_locked()` to check if tokens are still locked based on current timestamp
+  - Implement `read_lockup()` helper to read LockupInfo from storage
+  - Implement `write_lockup()` helper to write LockupInfo to storage
+  - Implement `remove_lockup()` helper to remove lock from storage
+  - _Requirements: 2.1, 2.2, 2.7_
+
+- [ ]* 1.1 Write unit tests for helper functions
+  - Test `get_locked_amount()` returns 0 for non-existent locks
+  - Test `get_locked_amount()` returns correct amount for existing locks
+  - Test `is_locked()` returns true when timestamp < unlock_time
+  - Test `is_locked()` returns false when timestamp >= unlock_time
+
+### Phase 2: Core Locking Function
+
+- [ ] 2. Implement lock_tokens function
+  - Verify contract is initialized (return `NotInitialized` if not)
+  - Verify caller is admin via `require_auth()`
+  - Validate amount > 0 (return `InvalidAmount` if not)
+  - Validate amount <= user's available balance (return `InsufficientBalance` if not)
+  - Deduct amount from user's available balance
+  - Create or update LockupInfo: accumulate amount, use maximum unlock_time
+  - Store updated LockupInfo in persistent storage
+  - Emit lock event with user, amount, and unlock_time
+  - Return `Ok(())`
+  - _Requirements: 1.1-1.8, 2.1-2.7_
+
+- [ ]* 2.1 Write unit tests for lock_tokens
+  - Test valid lock: verify balance decreases and lock is stored
+  - Test non-admin lock: verify authorization error
+  - Test insufficient balance: verify `InsufficientBalance` error
+  - Test invalid amount (zero): verify `InvalidAmount` error
+  - Test invalid amount (negative): verify `InvalidAmount` error
+  - Test uninitialized contract: verify `NotInitialized` error
+  - Test lock event emission: verify event contains correct data
+
+- [ ]* 2.2 Write property test for lock accumulation
+  - **Property 2: Lock Accumulation**
+  - Generate random sequences of lock operations with varying amounts
+  - Verify total locked amount equals sum of all amounts
+  - Verify unlock_time equals maximum of all provided times
+  - Run minimum 100 iterations
+
+- [ ]* 2.3 Write property test for unlock time monotonicity
+  - **Property 20: Unlock Time Monotonicity**
+  - Generate random sequences of lock operations with varying unlock times
+  - Verify unlock_time never decreases
+  - Verify final unlock_time equals maximum of all times
+  - Run minimum 100 iterations
+
+### Phase 3: Core Withdrawal Function
+
+- [ ] 3. Implement withdraw_locked function
+  - Verify contract is initialized (return `NotInitialized` if not)
+  - Verify caller is the user via `require_auth()`
+  - Read LockupInfo from storage (panic if not found)
+  - Verify current ledger timestamp >= unlock_time (panic if not)
+  - Add locked amount back to user's available balance
+  - Remove LockupInfo from persistent storage
+  - Emit withdraw event with user and withdrawn amount
+  - _Requirements: 4.1-4.7, 5.1-5.6_
+
+- [ ]* 3.1 Write unit tests for withdraw_locked
+  - Test valid withdrawal: lock then withdraw after unlock_time, verify balance restored
+  - Test non-owner withdrawal: verify authorization error
+  - Test no lock exists: verify error/panic
+  - Test premature withdrawal: verify panic with "tokens are still locked"
+  - Test storage removal: verify lock is removed after withdrawal
+  - Test double withdrawal: verify second call fails
+  - Test uninitialized contract: verify `NotInitialized` error
+  - Test withdraw event emission: verify event contains correct data
+
+- [ ]* 3.2 Write property test for withdrawal eligibility
+  - **Property 9: Withdrawal Eligibility at Unlock Time**
+  - Generate random unlock times and current timestamps
+  - Lock with unlock_time
+  - Attempt withdrawal at current_timestamp
+  - Verify failure if current_timestamp < unlock_time
+  - Verify success if current_timestamp >= unlock_time
+  - Run minimum 100 iterations
+
+### Phase 4: Transfer Function Integration
+
+- [ ] 4. Modify transfer function to respect locked amounts
+  - Add validation: calculate available_balance = total_balance - locked_amount
+  - Check if transfer_amount > available_balance
+  - Return `InsufficientBalance` if transfer exceeds available balance
+  - Proceed with transfer if validation passes
+  - Ensure existing transfer logic remains unchanged
+  - _Requirements: 3.1-3.8, 9.1-9.7_
+
+- [ ] 5. Modify transfer_from function to respect locked amounts
+  - Add validation: calculate available_balance = total_balance - locked_amount for source user
+  - Check if transfer_amount > available_balance
+  - Return `InsufficientBalance` if transfer exceeds available balance
+  - Proceed with transfer if validation passes
+  - Ensure existing transfer_from logic remains unchanged
+  - _Requirements: 3.3-3.4, 9.2-9.3_
+
+- [ ] 6. Modify burn function to respect locked amounts
+  - Add validation: calculate available_balance = total_balance - locked_amount
+  - Check if burn_amount > available_balance
+  - Return `InsufficientBalance` if burn exceeds available balance
+  - Proceed with burn if validation passes
+  - Ensure existing burn logic remains unchanged
+  - _Requirements: 3.3-3.4, 9.3_
+
+- [ ] 7. Modify burn_from function to respect locked amounts
+  - Add validation: calculate available_balance = total_balance - locked_amount for source user
+  - Check if burn_amount > available_balance
+  - Return `InsufficientBalance` if burn exceeds available balance
+  - Proceed with burn_from if validation passes
+  - Ensure existing burn_from logic remains unchanged
+  - _Requirements: 3.3-3.4, 9.4_
+
+- [ ] 8. Modify clawback function to respect locked amounts
+  - Add validation: calculate available_balance = total_balance - locked_amount
+  - Check if clawback_amount > available_balance
+  - Return `InsufficientBalance` if clawback exceeds available balance
+  - Proceed with clawback if validation passes
+  - Ensure locked tokens remain unchanged after clawback
+  - _Requirements: 10.1-10.4_
+
+- [ ]* 8.1 Write unit tests for transfer prevention
+  - Test transfer with locked tokens: lock partial amount, transfer available, verify success
+  - Test transfer exceeds available: lock amount, attempt transfer > available, verify error
+  - Test transfer_from with locked: lock source user, attempt transfer_from, verify lock respected
+  - Test burn with locked: lock amount, attempt burn > available, verify error
+  - Test balance includes locked: lock amount, query balance, verify includes locked
+
+- [ ]* 8.2 Write property test for transfer prevention
+  - **Property 6: Transfer Prevention for Locked Amounts**
+  - Generate random lock amounts and transfer amounts
+  - Lock the amount
+  - Attempt transfer
+  - Verify failure if transfer_amount > available_balance
+  - Verify success if transfer_amount <= available_balance
+  - Run minimum 100 iterations
+
+- [ ]* 8.3 Write property test for available balance calculation
+  - **Property 7: Available Balance Calculation**
+  - Generate random initial balance and lock amount
+  - Lock the amount
+  - Verify available_balance = total_balance - locked_amount
+  - Verify transfers respect available_balance
+  - Run minimum 100 iterations
+
+### Phase 5: Event Emission
+
+- [ ] 9. Implement lock event emission
+  - Add `emit_locked()` function to events module (if not already present)
+  - Event symbol: "locked"
+  - Event data: user address, locked amount, unlock_time
+  - Call `emit_locked()` in `lock_tokens()` after successful lock
+  - _Requirements: 1.7, 8.1, 8.3, 8.5_
+
+- [ ] 10. Implement withdraw event emission
+  - Add `emit_withdraw_locked()` function to events module (if not already present)
+  - Event symbol: "withdraw_locked"
+  - Event data: user address, withdrawn amount
+  - Call `emit_withdraw_locked()` in `withdraw_locked()` after successful withdrawal
+  - _Requirements: 4.6, 8.2, 8.4, 8.6_
+
+- [ ]* 10.1 Write unit tests for event emission
+  - Test lock event: call lock_tokens and verify event contains correct user, amount, unlock_time
+  - Test withdraw event: call withdraw_locked and verify event contains correct user and amount
+  - Test multiple lock events: call lock_tokens multiple times, verify each emits separate event
+  - Test withdraw event amount: verify event contains total accumulated amount
+
+### Phase 6: Admin Transfer Integration
+
+- [ ] 11. Verify admin transfer integration
+  - Verify `transfer_ownership()` allows new admin to call `lock_tokens`
+  - Verify `propose_owner()` and `accept_ownership()` allow new admin to call `lock_tokens`
+  - Verify old admin cannot call `lock_tokens` after transfer
+  - Verify locked tokens persist after admin transfer
+  - _Requirements: 7.2-7.4, 17.1-17.4_
+
+- [ ]* 11.1 Write unit tests for admin transfer integration
+  - Test transfer_ownership: transfer admin, verify new admin can lock
+  - Test propose_owner/accept_ownership: propose and accept, verify new admin can lock
+  - Test old admin rejection: verify old admin cannot lock after transfer
+  - Test locked tokens persist: lock tokens, transfer admin, verify locks persist
+
+### Phase 7: Pause State Integration
+
+- [ ] 12. Verify pause state integration
+  - Verify `lock_tokens` works when contract is paused
+  - Verify `withdraw_locked` works when contract is paused
+  - Verify `transfer` fails when contract is paused (existing behavior)
+  - Verify `balance` returns total balance including locked when paused
+  - _Requirements: 11.1-11.4_
+
+- [ ]* 12.1 Write unit tests for pause state integration
+  - Test lock during pause: pause contract, call lock_tokens, verify success
+  - Test withdraw during pause: pause contract, call withdraw_locked, verify success
+  - Test transfer during pause: pause contract, attempt transfer, verify failure
+  - Test balance during pause: pause contract, query balance, verify includes locked
+
+### Phase 8: Edge Cases and Constraints
+
+- [ ] 13. Handle edge cases
+  - Accept unlock_time equal to current timestamp (allow immediate withdrawal)
+  - Accept very large unlock_time values without overflow
+  - Accept unlock_time of zero (no validation)
+  - Handle integer overflow on lock accumulation (panic or return error)
+  - Handle rapid successive lock calls (accumulate correctly)
+  - _Requirements: 12.1-12.7_
+
+- [ ]* 13.1 Write unit tests for edge cases
+  - Test unlock_time equal to current: lock with current timestamp, verify immediate withdrawal
+  - Test large unlock_time: lock with far future timestamp, verify storage
+  - Test zero unlock_time: lock with zero, verify immediate withdrawal
+  - Test rapid locks: lock multiple times rapidly, verify accumulation
+  - Test contract upgrade: lock tokens, upgrade contract, verify locks persist
+
+### Phase 9: Property-Based Tests (Correctness Properties)
+
+- [ ]* 14-27. Write property tests for all 20 correctness properties
+  - Property 1: Lock Deducts from Available Balance
+  - Property 3: Unlock Time Maximization
+  - Property 4: Lock Storage Persistence
+  - Property 5: Lock Event Emission
+  - Property 8: Locked Tokens Remain Locked Until Withdrawal
+  - Property 10: Withdrawal Removes Lock Storage
+  - Property 11: Withdrawal Event Emission
+  - Property 12: Partial Lock Leaves Remainder Transferable
+  - Property 13: Clawback Respects Locked Amounts
+  - Property 14: Withdrawal Requires User Authorization
+  - Property 15: Lock Requires Admin Authorization
+  - Property 16: Admin Transfer Preserves Locking Authority
+  - Property 17: Balance Includes Locked Tokens
+  - Property 18: Lock Operations Work During Pause
+  - Property 19: Multiple Withdrawals Fail After First
+  - Each with minimum 100 iterations
+
+### Phase 10: Integration Tests
+
+- [ ]* 28. Write integration test for complete lock-withdraw cycle
+  - Initialize contract, mint tokens to user
+  - Lock tokens as admin
+  - Verify balance reflects locked amount
+  - Attempt transfer (should fail)
+  - Advance time past unlock_time
+  - Withdraw locked tokens
+  - Verify balance restored
+  - Verify transfer now succeeds
+
+- [ ]* 29. Write integration test for multiple lock tranches
+  - Initialize contract, mint tokens to user
+  - Lock first tranche with unlock_time_1
+  - Lock second tranche with unlock_time_2 (later)
+  - Verify total locked = sum of tranches
+  - Verify unlock_time = maximum
+  - Advance time past unlock_time_2
+  - Withdraw all locked tokens
+  - Verify all tranches withdrawn
+
+- [ ]* 30. Write integration test for clawback with locked tokens
+  - Initialize contract, mint tokens to user
+  - Lock partial amount
+  - Clawback from available balance
+  - Verify locked tokens unchanged
+  - Verify clawback succeeded
+
+- [ ]* 31. Write integration test for admin transfer with locked tokens
+  - Initialize contract, mint tokens to user
+  - Lock tokens as admin
+  - Transfer admin ownership
+  - Verify new admin can lock additional tokens
+  - Verify old admin cannot lock
+  - Verify all locks persist
+
+- [ ]* 32. Write integration test for pause state with locked tokens
+  - Initialize contract, mint tokens to user
+  - Lock tokens
+  - Pause contract
+  - Verify lock_tokens still works
+  - Verify withdraw_locked still works
+  - Verify transfer fails
+  - Unpause contract
+  - Verify transfer works
+
+### Phase 11: Checkpoint and Verification
+
+- [ ] 33. Checkpoint - Ensure all tests pass
+  - Run all unit tests and verify they pass
+  - Run all property-based tests and verify they pass (minimum 100 iterations each)
+  - Run all integration tests and verify they pass
+  - Verify no compilation errors or warnings
+  - Verify code follows project style and conventions
+
+- [ ] 34. Checkpoint - Verify requirements coverage
+  - Verify all 12 requirements are covered by implementation tasks
+  - Verify all 20 correctness properties are covered by property-based tests
+  - Verify all acceptance criteria are addressed
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property-based tests use randomized input generation with minimum 100 iterations per property
+- All tests should use snapshot testing for event verification where applicable
+- The implementation maintains backward compatibility with existing transfer functions
+- Lock information persists across contract upgrades via persistent storage


### PR DESCRIPTION
Closes #63 
Closes #55 

Description
This PR delivers two key functional upgrades to the token contract:

Token Locking & Vesting (#63): Introduces time-based token locking mechanics, restricting users from transferring balances that are currently tied up in a vesting or lock-up schedule.

Metadata Updates (#55): Re-implements admin-gated functions allowing the contract owner to update the token's name and symbol post-initialization.

Changes
1. Token Locking & Vesting (#63)
Storage & State: Introduced a new storage architecture to track locked amounts and their corresponding UNIX unlock timestamps per account.

Transfer Constraints: Updated the core transfer and transfer_from logic to calculate a user's spendable balance. The contract now strictly blocks transactions where the transfer amount exceeds total_balance - locked_balance.

Locking Mechanism: Added an interface/helper to define lock periods, ensuring funds remain illiquid until the ledger timestamp surpasses the unlock time.

2. Metadata Management (#55)
Admin Functions: Added the update_name and update_symbol functions to the public contract interface.

Authorization: Gated both functions behind strict administrative authentication (admin.require_auth()) to prevent unauthorized metadata manipulation.

State Updates: Ensured the underlying metadata storage keys are successfully overwritten and persisted upon an authorized update.

Acceptance Criteria Verification
[x] Locking logic and dedicated storage keys implemented.

[x] Transfers of locked balances are successfully prevented.

[x] update_name and update_symbol functions implemented.

[x] Metadata update functions are securely gated by admin authorization.

[x] Comprehensive test suites added for both features.

Testing Checklist
Locking & Vesting Tests
[ ] Attempt transfer with zero locked tokens (Should succeed).

[ ] Attempt transfer exceeding the available unlocked balance (Should fail).

[ ] Attempt transfer within the bounds of the unlocked balance (Should succeed).

[ ] Attempt transfer of locked tokens after the unlock timestamp has passed (Should succeed).

Metadata Update Tests
[ ] Call update_name and update_symbol as the authorized Admin (Should succeed and update state).

[ ] Call update_name and update_symbol from a non-admin account (Should fail authentication).

[ ] Verify getters (name() and symbol()) return the updated strings post-modification.