### PR TITLE
fixes

### DIFF
--- a/contracts/rate-limit/src/lib.rs
+++ b/contracts/rate-limit/src/lib.rs
@@ -52,10 +52,17 @@ impl BcForgeRateLimit {
             .get::<_, RateLimitConfig>(&DataKey::GlobalRateLimit(operation_type.clone()))
     }
 
-    fn get_address_config(env: &Env, address: &Address, operation_type: &String) -> Option<RateLimitConfig> {
+    fn get_address_config(
+        env: &Env,
+        address: &Address,
+        operation_type: &String,
+    ) -> Option<RateLimitConfig> {
         env.storage()
             .instance()
-            .get::<_, RateLimitConfig>(&DataKey::AddressRateLimit(address.clone(), operation_type.clone()))
+            .get::<_, RateLimitConfig>(&DataKey::AddressRateLimit(
+                address.clone(),
+                operation_type.clone(),
+            ))
     }
 
     fn get_global_state(env: &Env, operation_type: &String) -> RateLimitState {
@@ -71,14 +78,23 @@ impl BcForgeRateLimit {
     fn get_address_state(env: &Env, address: &Address, operation_type: &String) -> RateLimitState {
         env.storage()
             .instance()
-            .get::<_, RateLimitState>(&DataKey::AddressCount(address.clone(), operation_type.clone()))
+            .get::<_, RateLimitState>(&DataKey::AddressCount(
+                address.clone(),
+                operation_type.clone(),
+            ))
             .unwrap_or(RateLimitState {
                 count: 0,
                 last_reset: 0,
             })
     }
 
-    fn reset_if_needed(env: &Env, current_time: u64, config: &RateLimitConfig, state: &mut RateLimitState, key: &DataKey) {
+    fn reset_if_needed(
+        env: &Env,
+        current_time: u64,
+        config: &RateLimitConfig,
+        state: &mut RateLimitState,
+        key: &DataKey,
+    ) {
         if current_time >= state.last_reset + config.window_seconds {
             state.count = 0;
             state.last_reset = current_time;
@@ -97,14 +113,14 @@ impl BcForgeRateLimit {
         env: &Env,
         address: Option<&Address>,
         operation_type: &String,
-        amount: u64,
+        _amount: u64,
     ) -> bool {
         let current_time = Self::get_current_timestamp(env);
 
         // Check global rate limit first
         if let Some(global_config) = Self::get_global_config(env, operation_type) {
             let mut global_state = Self::get_global_state(env, operation_type);
-            
+
             Self::reset_if_needed(
                 env,
                 current_time,
@@ -128,7 +144,7 @@ impl BcForgeRateLimit {
         if let Some(addr) = address {
             if let Some(address_config) = Self::get_address_config(env, addr, operation_type) {
                 let mut address_state = Self::get_address_state(env, addr, operation_type);
-                
+
                 Self::reset_if_needed(
                     env,
                     current_time,
@@ -180,9 +196,10 @@ impl BcForgeRateLimit {
             limit,
             window_seconds,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::AddressRateLimit(address.clone(), operation_type.clone()), &config);
+        env.storage().instance().set(
+            &DataKey::AddressRateLimit(address.clone(), operation_type.clone()),
+            &config,
+        );
     }
 }
 
@@ -194,10 +211,10 @@ impl BcForgeRateLimit {
         env: Env,
         address: Option<Address>,
         operation_type: soroban_sdk::String,
-        amount: u64,
+        _amount: u64,
     ) -> bool {
         let address_ref = address.as_ref();
-        BcForgeRateLimit::internal_check_rate_limit(&env, address_ref, &operation_type, amount)
+        BcForgeRateLimit::internal_check_rate_limit(&env, address_ref, &operation_type, _amount)
     }
 
     /// Set global rate limit for an operation type
@@ -207,7 +224,12 @@ impl BcForgeRateLimit {
         limit: u64,
         window_seconds: u64,
     ) {
-        BcForgeRateLimit::internal_set_global_rate_limit(&env, &operation_type, limit, window_seconds)
+        BcForgeRateLimit::internal_set_global_rate_limit(
+            &env,
+            &operation_type,
+            limit,
+            window_seconds,
+        )
     }
 
     /// Set per-address rate limit for an operation type
@@ -218,6 +240,12 @@ impl BcForgeRateLimit {
         limit: u64,
         window_seconds: u64,
     ) {
-        BcForgeRateLimit::internal_set_address_rate_limit(&env, &address, &operation_type, limit, window_seconds)
+        BcForgeRateLimit::internal_set_address_rate_limit(
+            &env,
+            &address,
+            &operation_type,
+            limit,
+            window_seconds,
+        )
     }
 }

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -326,6 +326,10 @@ impl TokenInterface for BcForgeToken {
             soroban_sdk::panic_with_error!(&env, TokenError::InvalidAmount);
         }
 
+        if !crate::rate_limit::check_transfer_from_rate_limit(&env, &spender, amount) {
+            soroban_sdk::panic_with_error!(&env, TokenError::InvalidAmount);
+        }
+
         let allowance = Self::allowance_amount(&env, &from, &spender);
         if allowance < amount {
             soroban_sdk::panic_with_error!(&env, TokenError::InsufficientAllowance);
@@ -375,6 +379,10 @@ impl TokenInterface for BcForgeToken {
         Self::panic_on_err(&env, Self::ensure_not_paused(&env));
         spender.require_auth();
         if amount <= 0 {
+            soroban_sdk::panic_with_error!(&env, TokenError::InvalidAmount);
+        }
+
+        if !crate::rate_limit::check_burn_from_rate_limit(&env, &spender, amount) {
             soroban_sdk::panic_with_error!(&env, TokenError::InvalidAmount);
         }
 

--- a/contracts/token/src/rate_limit.rs
+++ b/contracts/token/src/rate_limit.rs
@@ -3,8 +3,8 @@
 //! Integrates the bc-forge-rate-limit contract with the token contract
 //! to enforce rate limiting on mint and transfer operations.
 
-use soroban_sdk::{Address, Env, String};
 use bc_forge_rate_limit::BcForgeRateLimit;
+use soroban_sdk::{Address, Env, String};
 
 /// Operation types for rate limiting
 pub const OPERATION_MINT: &str = "mint";

--- a/contracts/token/src/reentrancy_guard.rs
+++ b/contracts/token/src/reentrancy_guard.rs
@@ -3,7 +3,7 @@
 //! Implements a reentrancy protection pattern to prevent cross-contract callback attacks.
 //! This guard ensures that state-modifying functions cannot be re-entered during execution.
 
-use soroban_sdk::{contracttype, symbol_short, Env, Symbol};
+use soroban_sdk::{contracttype, Env, Symbol};
 
 /// Reentrancy guard state
 #[derive(Clone, Debug, PartialEq)]
@@ -78,7 +78,8 @@ impl ReentrancyGuard {
 #[macro_export]
 macro_rules! reentrancy_guard {
     ($env:expr, $key:expr, $body:block) => {{
-        let guard = $crate::reentrancy_guard::ReentrancyGuard::new(soroban_sdk::Symbol::new($env, $key));
+        let guard =
+            $crate::reentrancy_guard::ReentrancyGuard::new(soroban_sdk::Symbol::new($env, $key));
         guard.require_not_entered($env);
         let result = (|| $body)();
         guard.exit($env);


### PR DESCRIPTION
This PR addresses several compiler warnings and resolves a significant logic gap in the token contract where allowance spenders could bypass the global and per-address rate limits.

Changes Proposed
🔒 Logic & Security Fixes
Enforced Rate Limits on Spender Operations (contracts/token/src/lib.rs)
The Issue: The transfer_from and burn_from functions were missing their respective rate limit validation checks. While standard operations (mint, transfer, burn) properly checked limits, a spender utilizing an allowance could perform operations without being subjected to the contract's rate limits.
The Fix: Injected check_transfer_from_rate_limit and check_burn_from_rate_limit into their respective token functions. If a rate limit is exceeded, the transaction now correctly aborts with TokenError::InvalidAmount.
🧹 Code Quality & Warning Resolutions
Silenced unused variable in Rate Limiter (contracts/rate-limit/src/lib.rs)
Prefixed the amount parameter with an underscore (_amount) in check_rate_limit and internal_check_rate_limit. Since the current implementation limits based on the number of operations (via state.count += 1) rather than the token sum, the amount variable is intentionally ignored. This clears the #[warn(unused_variables)] alert.
Removed unused import (contracts/token/src/reentrancy_guard.rs)
Removed the unused symbol_short import from soroban_sdk. The module's macro utilizes soroban_sdk::Symbol::new() directly, rendering the macro import redundant and clearing the #[warn(unused_imports)] alert.
Testing Performed
Verified that the Rust compiler successfully builds the project without emitting unused_variables or unused_imports warnings.
Confirmed that crate::rate_limit validations are correctly gated prior to the execution of balance transfers within the _from operations.